### PR TITLE
Bump yangtools to 2.0.5

### DIFF
--- a/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.5</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>

--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -95,7 +95,7 @@
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This bumps the yangtools dependency to 2.0.5.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>