### PR TITLE
Bump odlparent dependency

### DIFF
--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Oxygen SR2 is using odlparent-3.1.1, fix that.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>