### PR TITLE
Versions update to oxygen SR3

### DIFF
--- a/lighty-codecs/pom.xml
+++ b/lighty-codecs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-core/lighty-parents/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -14,13 +14,12 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parents/lighty-parent</relativePath>
     </parent>
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-common</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -43,7 +42,7 @@
         <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>log4j-properties</artifactId>
-            <version>8.2.0-SNAPSHOT</version>
+            <version>${lighty.version}</version>
         </dependency>
 
         <!--Tests-->

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parents/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parents/lighty-parent</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-common</artifactId>
-            <version>8.2.0-SNAPSHOT</version>
+            <version>${lighty.version}</version>
         </dependency>
 
         <dependency>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.opendaylight.infrautils</groupId>
             <artifactId>diagstatus-api</artifactId>
-            <version>1.3.3-SNAPSHOT</version>
+            <version>1.3.3</version>
         </dependency>
         <!--odl-yangtools-common-->
         <dependency>

--- a/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
@@ -57,7 +57,7 @@
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>0.12.3-SNAPSHOT</version>
+                        <version>0.12.3</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parent/</relativePath>
     </parent>
 
@@ -22,9 +22,7 @@
         This is a parent suitable for packaging Yang models with their Java v1 bindings.
         The binding-parent from ODL activates too many unimportant plugins.
     -->
-    <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-binding-parent</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-core/lighty-parents/lighty-community-restconf-app-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-community-restconf-app-parent/pom.xml
@@ -14,13 +14,11 @@
     <parent>
         <groupId>io.lighty.kit.examples.parents</groupId>
         <artifactId>lighty-controller-app-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-controller-app-parent/</relativePath>
     </parent>
 
-    <groupId>io.lighty.kit.examples.parents</groupId>
     <artifactId>lighty-community-restconf-app-parent</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <profiles>

--- a/lighty-core/lighty-parents/lighty-community-restconf-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-community-restconf-parent/pom.xml
@@ -14,13 +14,11 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parent/</relativePath>
     </parent>
 
-    <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-community-restconf-parent</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-core/lighty-parents/lighty-controller-app-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-controller-app-parent/pom.xml
@@ -14,13 +14,12 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parent/</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.parents</groupId>
     <artifactId>lighty-controller-app-parent</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -15,7 +15,7 @@
         <groupId>io.lighty.core.parents</groupId>
         <!-- TODO: Prefer explicit versions over properties. -->
         <artifactId>lighty-properties-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-properties-parent/</relativePath>
     </parent>
 
@@ -24,10 +24,7 @@
         This way, parent poms with unrelated parents can import versions defined here,
         in such a place which gives them control over maven version conflict resolution.
     -->
-
-    <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-dependency-artifacts</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencyManagement>

--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -44,21 +44,21 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.7.3-SNAPSHOT</version>
+                <version>0.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>config-artifacts</artifactId>
-                <version>0.8.3-SNAPSHOT</version>
+                <version>0.8.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>1.7.3-SNAPSHOT</version>
+                <version>1.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -67,28 +67,28 @@
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>2.4.3-SNAPSHOT</version>
+                <version>2.4.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal.model</groupId>
                 <artifactId>mdsal-model-artifacts</artifactId>
-                <version>0.12.3-SNAPSHOT</version>
+                <version>0.12.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>restconf-artifacts</artifactId>
-                <version>1.7.3-SNAPSHOT</version>
+                <version>1.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.4.3-SNAPSHOT</version>
+                <version>1.4.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parents/lighty-parent-no-plugins/pom.xml
+++ b/lighty-core/lighty-parents/lighty-parent-no-plugins/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-properties-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-properties-parent/</relativePath>
     </parent>
 
@@ -23,9 +23,7 @@
         This does not contain any plugins, as not every potential descendant needs them.
     -->
 
-    <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-parent-no-plugins</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencyManagement>
@@ -33,7 +31,7 @@
             <dependency>
                 <groupId>io.lighty.core.parents</groupId>
                 <artifactId>lighty-dependency-artifacts</artifactId>
-                <version>8.2.0-SNAPSHOT</version>
+                <version>${lighty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parents/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-parent/pom.xml
@@ -14,15 +14,13 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent-no-plugins</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../lighty-parent-no-plugins/</relativePath>
     </parent>
 
     <!-- This is the main parent for building LightyModule jars. -->
 
-    <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-parent</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-core/lighty-parents/lighty-properties-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-properties-parent/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-properties-parent</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -23,7 +23,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <leveldb.version>0.7</leveldb.version>
-        <lighty.version>8.2.0-SNAPSHOT</lighty.version>
+        <lighty.version>8.3.0</lighty.version>
         <snmp.version>0.1.0-SNAPSHOT</snmp.version>
         <!-- test dependencies -->
         <testng.version>6.13</testng.version>

--- a/lighty-core/lighty-parents/pom.xml
+++ b/lighty-core/lighty-parents/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.core.parents</groupId>
     <artifactId>lighty-parents-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-core-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-examples/controllers/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/controllers/lighty-community-restconf-netconf-app/README.md
@@ -14,12 +14,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * got to target directory ```cd lighty-examples/controllers/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-8.3.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-8.3.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-8.3.0.jar```
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-8.3.0.jar```
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -29,7 +29,7 @@ RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*``
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-8.3.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/controllers/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/controllers/lighty-community-restconf-netconf-app/pom.xml
@@ -14,13 +14,12 @@
     <parent>
         <groupId>io.lighty.kit.examples.parents</groupId>
         <artifactId>lighty-community-restconf-app-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../../lighty-core/lighty-parents/lighty-community-restconf-app-parent/</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-community-restconf-netconf-app</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/lighty-examples/controllers/lighty-community-restconf-netconf-app/src/main/assembly/resources/start-controller.sh
+++ b/lighty-examples/controllers/lighty-community-restconf-netconf-app/src/main/assembly/resources/start-controller.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #start controller with java 8
-java -jar lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-netconf-app-8.3.0.jar sampleConfigSingleNode.json
 
 
 #start controller with java 10 or later
-#java --add-modules java.xml.bind -jar lighty-community-restconf-netconf-app-8.2.0-SNAPSHOT.jar sampleConfigSingleNode.json
+#java --add-modules java.xml.bind -jar lighty-community-restconf-netconf-app-8.3.0.jar sampleConfigSingleNode.json

--- a/lighty-examples/controllers/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/controllers/lighty-controller-springboot-netconf/README.md
@@ -31,7 +31,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-8.2.0-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-8.3.0.jar
 ```
 
 or in any IDE, run the method

--- a/lighty-examples/controllers/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/controllers/lighty-controller-springboot-netconf/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller-springboot</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>jar</packaging>
 
     <name>lighty-controller-springboot</name>
@@ -30,7 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <lighty.version>8.2.0-SNAPSHOT</lighty.version>
+        <lighty.version>8.3.0</lighty.version>
     </properties>
 
     <dependencies>

--- a/lighty-examples/controllers/pom.xml
+++ b/lighty-examples/controllers/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-controller-apps-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-examples/pom.xml
+++ b/lighty-examples/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.kit.examples</groupId>
     <artifactId>example-applications-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-models/pom.xml
+++ b/lighty-models/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-models/test/lighty-test-models/pom.xml
+++ b/lighty-models/test/lighty-test-models/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../../lighty-core/lighty-parents/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-toaster/pom.xml
+++ b/lighty-models/test/lighty-toaster/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../../lighty-core/lighty-parents/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/pom.xml
+++ b/lighty-models/test/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.models.test</groupId>
     <artifactId>lighty-models-test-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-modules/northbound-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/northbound-modules/lighty-restconf-nb-community/README.md
@@ -13,7 +13,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules.northbound.restconf</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
   </dependency>
 ```
 
@@ -65,8 +65,8 @@ Default Models
 --------------
 CommunityRestConf requires following models to be loaded by LightyController.
 ```
-  "mvn:org.opendaylight.netconf/ietf-yang-library/1.7.0-SNAPSHOT",
-  "mvn:org.opendaylight.netconf/ietf-restconf-monitoring/1.7.0-SNAPSHOT"
+  "mvn:org.opendaylight.netconf/ietf-yang-library/1.7.3",
+  "mvn:org.opendaylight.netconf/ietf-restconf-monitoring/1.7.3"
 ```
 
 Clustering

--- a/lighty-modules/northbound-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/northbound-modules/lighty-restconf-nb-community/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-community-restconf-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../../lighty-core/lighty-parents/lighty-community-restconf-parent</relativePath>
     </parent>
 

--- a/lighty-modules/northbound-modules/lighty-server/pom.xml
+++ b/lighty-modules/northbound-modules/lighty-server/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-community-restconf-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../../lighty-core/lighty-parents/lighty-community-restconf-parent</relativePath>
     </parent>
 

--- a/lighty-modules/northbound-modules/pom.xml
+++ b/lighty-modules/northbound-modules/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.modules.northbound</groupId>
     <artifactId>lighty-northbound-modules-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-modules/pom.xml
+++ b/lighty-modules/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-modules-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-modules/southbound-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/southbound-modules/lighty-netconf-sb/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-community-restconf-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../../lighty-core/lighty-parents/lighty-community-restconf-parent</relativePath>
     </parent>
 

--- a/lighty-modules/southbound-modules/pom.xml
+++ b/lighty-modules/southbound-modules/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.modules.southbound</groupId>
     <artifactId>lighty-southbound-modules-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-resources/controller-application-assembly/pom.xml
+++ b/lighty-resources/controller-application-assembly/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../lighty-core/lighty-parents/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/log4j-properties/pom.xml
+++ b/lighty-resources/log4j-properties/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../lighty-core/lighty-parents/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/pom.xml
+++ b/lighty-resources/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.lighty.resources</groupId>
     <artifactId>lighty-resources-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
 
     <modules>
         <module>log4j-properties</module>

--- a/lighty-resources/singlenode-configuration/pom.xml
+++ b/lighty-resources/singlenode-configuration/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core.parents</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>8.2.0-SNAPSHOT</version>
+        <version>8.3.0</version>
         <relativePath>../../lighty-core/lighty-parents/lighty-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty</groupId>
     <artifactId>lighty-aggregator</artifactId>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.3.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
- updated versions of ODL dependencies from oxygen snapshots to oxygen SR3 release
- updated versions of Lighty artifacts from 8.2.0-SNAPSHOT to 8.3.0