### PR TITLE
dependecy javax.ws.rs:javax.ws.rs-api:jar:2.0.1:compile excluded

### DIFF
--- a/lighty-core/lighty-parents/lighty-community-restconf-app-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-community-restconf-app-parent/pom.xml
@@ -36,6 +36,12 @@
                     <groupId>io.lighty.modules.northbound.restconf</groupId>
                     <artifactId>lighty-restconf-nb-community</artifactId>
                     <version>${lighty.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>javax.ws.rs</groupId>
+                            <artifactId>javax.ws.rs-api</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Duplicity and wrong version in dependency tree removed.