### PR TITLE
Fixed CVE-2018-7489: FasterXML jackson-databind before 2.8.11.1 and 2…

### DIFF
--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -102,7 +102,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.6.7.1</version>
+                <version>2.8.11.1</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
….9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525