### PR TITLE
Upgrade BouncyCastle

### DIFF
--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -153,8 +153,8 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk16</artifactId>
-                <version>1.46</version>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.60</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/lighty-modules/southbound-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/southbound-modules/lighty-netconf-sb/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
bcprov-jdk16 has not seen a release in years, use jdk15on, which is
properly supported, and upgrade it to the latest release.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>