### PR TITLE
Skip deployment of aggregator poms

### DIFF
--- a/lighty-core/lighty-parents/pom.xml
+++ b/lighty-core/lighty-parents/pom.xml
@@ -16,6 +16,11 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-properties-parent</module>
         <module>lighty-dependency-artifacts</module>
@@ -26,5 +31,4 @@
         <module>lighty-community-restconf-app-parent</module>
         <module>lighty-community-restconf-parent</module>
     </modules>
-
 </project>

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -16,6 +16,11 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-common</module>
         <module>lighty-parents</module>
@@ -23,6 +28,5 @@
         <module>lighty-controller-spring-di</module>
         <module>lighty-controller-guice-di</module>
     </modules>
-
 </project>
 

--- a/lighty-examples/controllers/pom.xml
+++ b/lighty-examples/controllers/pom.xml
@@ -16,10 +16,14 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-community-aaa-restconf-app</module>
         <module>lighty-community-restconf-netconf-app</module>
         <module>lighty-controller-springboot-netconf</module>
     </modules>
-
 </project>

--- a/lighty-examples/pom.xml
+++ b/lighty-examples/pom.xml
@@ -16,8 +16,12 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>controllers</module>
     </modules>
-
 </project>

--- a/lighty-models/pom.xml
+++ b/lighty-models/pom.xml
@@ -16,8 +16,12 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>test</module>
     </modules>
-
 </project>

--- a/lighty-modules/northbound-modules/pom.xml
+++ b/lighty-modules/northbound-modules/pom.xml
@@ -16,10 +16,14 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-aaa</module>
         <module>lighty-restconf-nb-community</module>
         <module>lighty-server</module>
     </modules>
-
 </project>

--- a/lighty-modules/pom.xml
+++ b/lighty-modules/pom.xml
@@ -16,11 +16,15 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>integration-tests</module>
         <module>integration-tests-aaa</module>
         <module>northbound-modules</module>
         <module>southbound-modules</module>
     </modules>
-
 </project>

--- a/lighty-modules/southbound-modules/pom.xml
+++ b/lighty-modules/southbound-modules/pom.xml
@@ -16,9 +16,13 @@
     <version>9.1.1</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-netconf-sb</module>
     </modules>
-
 </project>
 

--- a/lighty-resources/pom.xml
+++ b/lighty-resources/pom.xml
@@ -16,10 +16,14 @@
     <packaging>pom</packaging>
     <version>9.1.1</version>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>log4j-properties</module>
         <module>singlenode-configuration</module>
         <module>controller-application-assembly</module>
     </modules>
-
 </project>


### PR DESCRIPTION
Aggregator poms are purely internal to build system, we should
not publish them.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>