### PR TITLE
Upgrade BouncyCastle

### DIFF
--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -103,8 +103,8 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk16</artifactId>
-                <version>1.46</version>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.60</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/lighty-modules/southbound-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/southbound-modules/lighty-netconf-sb/pom.xml
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
bcprov-jdk16 has not seen a release in years, use jdk15on, which is
properly supported, and upgrade it to the latest release.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
(cherry picked from commit a6656df51891ed6bf796474edd542f9bd4812d30)