### PR TITLE
Align Fluorine SR1 MRI versions

### DIFF
--- a/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-parents/lighty-binding-parent/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>2.0.11</version>
+                <version>2.0.12</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>

--- a/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
+++ b/lighty-core/lighty-parents/lighty-dependency-artifacts/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>3.1.3</version>
+                <version>3.1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -137,7 +137,7 @@
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>2.0.11</version>
+                <version>2.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Fluorine SR1 shipped with odlparent-3.1.4 and yangtools-2.0.12,
make sure we use those versions.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>