### PR TITLE
Add datastore properties to controller configuration

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerBuilder.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerBuilder.java
@@ -73,6 +73,7 @@ public class LightyControllerBuilder {
                     this.controllerConfiguration.getModulesConfig(),
                     this.controllerConfiguration.getConfigDatastoreContext(),
                     this.controllerConfiguration.getOperDatastoreContext(),
+                    this.controllerConfiguration.getDatastoreProperties(),
                     modelSet
                     );
         } catch (final Exception e) {

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -121,6 +121,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     private final Properties distributedEosProperties;
     private final DatastoreContext configDatastoreContext;
     private final DatastoreContext operDatastoreContext;
+    private final Map<String, Object> datastoreProperties;
     private final String moduleShardsConfig;
     private final String modulesConfig;
     private final String restoreDirectoryPath;
@@ -179,7 +180,8 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
             final int maxDataBrokerFutureCallbackQueueSize, final int maxDataBrokerFutureCallbackPoolSize,
             final boolean metricCaptureEnabled, final int mailboxCapacity, final Properties distributedEosProperties,
             final String moduleShardsConfig, final String modulesConfig, final DatastoreContext configDatastoreContext,
-            final DatastoreContext operDatastoreContext, final Set<YangModuleInfo> modelSet) {
+            final DatastoreContext operDatastoreContext, final Map<String, Object> datastoreProperties,
+            final Set<YangModuleInfo> modelSet) {
         super(executorService);
         initSunXMLWriterProperty();
         this.actorSystemConfig = actorSystemConfig;
@@ -201,6 +203,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         this.moduleShardsConfig = moduleShardsConfig;
         this.configDatastoreContext = configDatastoreContext;
         this.operDatastoreContext = operDatastoreContext;
+        this.datastoreProperties = datastoreProperties;
         this.modelSet = modelSet;
         this.lightyDiagStatusService = new LightyDiagStatusServiceImpl();
         this.systemReadyMonitor = new LightySystemReadyMonitorImpl();
@@ -341,7 +344,8 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         final ConfigurationImpl configuration = new ConfigurationImpl(moduleShardsConfig, modulesConfig);
         final DatastoreContextIntrospector introspector = new DatastoreContextIntrospector(datastoreContext,
                 this.codecOld);
-        final DatastoreContextPropertiesUpdater updater = new DatastoreContextPropertiesUpdater(introspector, null);
+        final DatastoreContextPropertiesUpdater updater = new DatastoreContextPropertiesUpdater(introspector,
+                datastoreProperties);
         return DistributedDataStoreFactory.createInstance(domSchemaService, datastoreContext,
                 datastoreSnapshotRestore, actorSystemProvider, introspector, updater, configuration);
     }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/config/ControllerConfiguration.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/config/ControllerConfiguration.java
@@ -13,6 +13,7 @@ import com.google.common.base.Objects;
 import com.typesafe.config.Config;
 import io.lighty.core.controller.impl.util.DatastoreConfigurationUtils;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +46,8 @@ public class ControllerConfiguration {
     @JsonIgnore
     private DatastoreContext operDatastoreContext;
 
+    private Map<String, Object> datastoreProperties;
+
     public ControllerConfiguration() {
         this.domNotificationRouterConfig = new DOMNotificationRouterConfig();
         this.actorSystemConfig = new ActorSystemConfig();
@@ -52,6 +55,7 @@ public class ControllerConfiguration {
         this.distributedEosProperties = new Properties();
         this.configDatastoreContext = DatastoreConfigurationUtils.createDefaultConfigDatastoreContext();
         this.operDatastoreContext = DatastoreConfigurationUtils.createDefaultOperationalDatastoreContext();
+        this.datastoreProperties = DatastoreConfigurationUtils.getDefaultDatastoreProperties();
     }
 
     public static class  DOMNotificationRouterConfig {
@@ -331,6 +335,14 @@ public class ControllerConfiguration {
 
     public void setOperDatastoreContext(DatastoreContext operDatastoreContext) {
         this.operDatastoreContext = operDatastoreContext;
+    }
+
+    public Map<String, Object> getDatastoreProperties() {
+        return datastoreProperties;
+    }
+
+    public void setDatastoreProperties(Map<String, Object> datastoreProperties) {
+        this.datastoreProperties = datastoreProperties;
     }
 
     @Override

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/DatastoreConfigurationUtils.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/DatastoreConfigurationUtils.java
@@ -8,6 +8,8 @@
 package io.lighty.core.controller.impl.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.opendaylight.controller.cluster.datastore.DatastoreContext;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
@@ -68,6 +70,12 @@ public final class DatastoreConfigurationUtils {
                 .logicalStoreType(LogicalDatastoreType.CONFIGURATION)
                 .tempFileDirectory(TEMP_FILE_DIRECTORY)
                 .build();
+    }
+
+    public static Map<String, Object> getDefaultDatastoreProperties() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("operational.persistent", "false");
+        return props;
     }
 
 }


### PR DESCRIPTION
I'm trying lighty.io and found that setting persistent=false on DatastoreContext has no effect because it's reset by DatastoreContextIntrospector. This commit attempts to fix this by adding datastore properties to controller configuration.