### PR TITLE
Wipe cache before storing it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ script: mvn clean install
 cache:
   directories:
     - '$HOME/.m2/repository'
-
+before_cache:
+  - rm -rf $HOME/.m2/repository/io/lighty


### PR DESCRIPTION
Caching dependencies is nice, but we are also affecting the cache.
Make sure we wipe our artifacts.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>