### PR TITLE
Fix travis branch reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ addons:
       description: lighty.io
     notification_email: juraj.veverka@pantheon.tech
     build_command: mvn clean install
-    branch_pattern: 8.3.x
+    branch_pattern: 8.4.x


### PR DESCRIPTION
We are on 8.4.x, with 8.3.x being a relic.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>