### PR TITLE
Migrate components to current Neon versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,24 +25,12 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>3.1.4</version>
+                <version>4.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <!-- Overrides of odlparent -->
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>2.8.11.20181123</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>1.60</version>
-            </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
@@ -54,63 +42,56 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.8.1</version>
+                <version>0.9.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>config-artifacts</artifactId>
-                <version>0.9.1</version>
+                <version>0.11.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>1.8.1</version>
+                <version>1.9.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.4.1</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>2.5.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.opendaylight.mdsal.model</groupId>
-                <artifactId>mdsal-model-artifacts</artifactId>
-                <version>0.13.1</version>
+                <version>3.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.5.1</version>
+                <version>1.6.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>restconf-artifacts</artifactId>
-                <version>1.8.1</version>
+                <version>1.9.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>2.0.12</version>
+                <version>2.1.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -51,12 +51,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>2.0.12</version>
+                <version>2.1.8</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>0.13.1</version>
+                        <version>1.0.6</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
@@ -7,8 +7,12 @@
  */
 package io.lighty.codecs;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import io.lighty.codecs.api.Codec;
 import io.lighty.codecs.api.NodeConverter;
+import io.lighty.codecs.xml.XmlElement;
+import io.lighty.codecs.xml.XmlUtil;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -16,16 +20,16 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
+import javassist.ClassPool;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.dom.DOMSource;
-
-import io.lighty.codecs.xml.XmlElement;
-import io.lighty.codecs.xml.XmlUtil;
-import org.opendaylight.controller.md.sal.binding.impl.BindingToNormalizedNodeCodec;
-import org.opendaylight.controller.md.sal.binding.impl.BindingToNormalizedNodeCodecFactory;
+import org.opendaylight.mdsal.binding.dom.adapter.BindingToNormalizedNodeCodec;
+import org.opendaylight.mdsal.binding.dom.codec.gen.impl.StreamWriterGenerator;
+import org.opendaylight.mdsal.binding.dom.codec.impl.BindingNormalizedNodeCodecRegistry;
 import org.opendaylight.mdsal.binding.generator.impl.GeneratedClassLoadingStrategy;
+import org.opendaylight.mdsal.binding.generator.util.JavassistUtils;
 import org.opendaylight.restconf.common.errors.RestconfDocumentedException;
 import org.opendaylight.yangtools.rfc8040.model.api.YangDataSchemaNode;
 import org.opendaylight.yangtools.yang.binding.DataContainer;
@@ -52,8 +56,6 @@ import org.opendaylight.yangtools.yang.model.api.UnknownSchemaNode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 public class DataCodec<T extends DataObject> implements Codec<T> {
 
@@ -72,8 +74,10 @@ public class DataCodec<T extends DataObject> implements Codec<T> {
     private final SchemaContext schemaContext;
 
     public DataCodec(final SchemaContext schemaContext) {
-        this.codec = BindingToNormalizedNodeCodecFactory.newInstance(
-                GeneratedClassLoadingStrategy.getTCCLClassLoadingStrategy());
+        final BindingNormalizedNodeCodecRegistry registry = new BindingNormalizedNodeCodecRegistry(
+            StreamWriterGenerator.create(JavassistUtils.forClassPool(ClassPool.getDefault())));
+        this.codec = new BindingToNormalizedNodeCodec(GeneratedClassLoadingStrategy.getTCCLClassLoadingStrategy(),
+            registry);
         this.schemaContext = schemaContext;
         this.codec.onGlobalContextUpdated(schemaContext);
         this.deserializeIdentifierCodec = new DeserializeIdentifierCodec(schemaContext);
@@ -89,7 +93,7 @@ public class DataCodec<T extends DataObject> implements Codec<T> {
     }
 
     @Override
-    public Collection<T> convertBindingAwareList(final YangInstanceIdentifier identifier, MapNode mapNode) {
+    public Collection<T> convertBindingAwareList(final YangInstanceIdentifier identifier, final MapNode mapNode) {
         Collection<MapEntryNode> children = mapNode.getValue();
         List<T> resultList = Lists.newArrayListWithCapacity(children.size());
         for(MapEntryNode entry : children) {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.codecs.api;
 
-import org.opendaylight.controller.md.sal.binding.impl.BindingToNormalizedNodeCodec;
+import org.opendaylight.mdsal.binding.dom.adapter.BindingToNormalizedNodeCodec;
 import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
@@ -25,9 +25,9 @@ public interface Codec<BA extends DataObject> extends Serializer<BA>, Deserializ
      * @return codec
      */
     BindingToNormalizedNodeCodec getCodec();
-    
+
     NodeConverter withJson();
-    
+
     NodeConverter withXml();
 
     SchemaContext getSchemaContext();

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
@@ -116,9 +116,9 @@ public final class ConverterUtils {
 
     /**
      * @see ConverterUtils#getRpcQName(XmlElement)
-     * @throws IllegalArgumentException if there was a problem during parsing the XML document
      * @param inputString RPC name
      * @return {@link QName} for RPC name or empty.
+     * @throws IllegalArgumentException if there was a problem during parsing the XML document
      */
     public static Optional<QName> getRpcQName(String inputString) {
         try {

--- a/lighty-core/lighty-codecs/src/test/java/io/lighty/codecs/AbstractCodecTest.java
+++ b/lighty-core/lighty-codecs/src/test/java/io/lighty/codecs/AbstractCodecTest.java
@@ -166,7 +166,7 @@ public abstract class AbstractCodecTest {
      * 
      * @return {@link List} of loaded {@link YangModuleInfo}
      */
-    private List<YangModuleInfo> loadModuleInfos() {
+    private static List<YangModuleInfo> loadModuleInfos() {
         List<YangModuleInfo> moduleInfos = new LinkedList<>();
         ServiceLoader<YangModelBindingProvider> yangProviderLoader = ServiceLoader.load(YangModelBindingProvider.class);
         for (YangModelBindingProvider yangModelBindingProvider : yangProviderLoader) {
@@ -184,8 +184,7 @@ public abstract class AbstractCodecTest {
      */
     private SchemaContext getSchemaContext(List<YangModuleInfo> moduleInfos) {
         moduleInfoBackedCntxt.addModuleInfos(moduleInfos);
-        Optional<SchemaContext> tryToCreateSchemaContext =
-                moduleInfoBackedCntxt.tryToCreateSchemaContext().toJavaUtil();
+        Optional<SchemaContext> tryToCreateSchemaContext = moduleInfoBackedCntxt.tryToCreateSchemaContext();
         if (!tryToCreateSchemaContext.isPresent()) {
             throw new IllegalStateException();
         }

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -64,18 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>object-cache-guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>object-cache-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>object-cache-noop</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-common</artifactId>
         </dependency>
         <dependency>
@@ -204,16 +192,16 @@
             <artifactId>iana-afn-safi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>iana-if-type-2014-05-08</artifactId>
+            <groupId>org.opendaylight.mdsal.binding.model.iana</groupId>
+            <artifactId>iana-if-type</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-interfaces</artifactId>
+            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
+            <artifactId>rfc6991</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-yang-types-20130715</artifactId>
+            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
+            <artifactId>rfc7223</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
@@ -242,10 +230,6 @@
         <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>ietf-topology-l3-unicast-igp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-inet-types-2013-07-15</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
@@ -343,10 +327,6 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-inmemory-datastore</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>threadpool-config-impl</artifactId>
-        </dependency>
         <!--odl-akka-scala-2.12-->
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -427,6 +407,14 @@
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.opendaylight.controller</groupId>
+            <artifactId>threadpool-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.controller</groupId>
+            <artifactId>threadpool-config-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.uncommons.maths</groupId>
             <artifactId>uncommons-maths</artifactId>
         </dependency>
@@ -442,21 +430,25 @@
             <groupId>org.agrona</groupId>
             <artifactId>agrona</artifactId>
         </dependency>
-        <!--odl-akka-leveldb-0.7-->
+
+        <!-- See odl-akka-leveldb-0.10 -->
         <dependency>
             <groupId>org.iq80.leveldb</groupId>
             <artifactId>leveldb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.iq80.leveldb</groupId>
-            <artifactId>leveldb-api</artifactId>
-            <!-- TODO: Find a way to inherit me from ODL-->
-            <version>0.7</version>
+            <version>0.10</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.iq80.leveldb</groupId>
+                    <artifactId>leveldb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.fusesource.leveldbjni</groupId>
             <artifactId>leveldbjni-all</artifactId>
+            <version>1.8-odl</version>
         </dependency>
+
         <!--odl-mdsal-remoterpc-connector-->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -205,8 +205,8 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         this.operDatastoreContext = operDatastoreContext;
         this.datastoreProperties = datastoreProperties;
         this.modelSet = modelSet;
-        this.lightyDiagStatusService = new LightyDiagStatusServiceImpl();
         this.systemReadyMonitor = new LightySystemReadyMonitorImpl();
+        this.lightyDiagStatusService = new LightyDiagStatusServiceImpl(systemReadyMonitor);
     }
 
     /**
@@ -663,7 +663,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     }
 
     @Override
-    public ObjectRegistration<YangModuleInfo> registerModuleInfo(YangModuleInfo yangModuleInfo) {
+    public ObjectRegistration<YangModuleInfo> registerModuleInfo(final YangModuleInfo yangModuleInfo) {
         return moduleInfoBackedContext.registerModuleInfo(yangModuleInfo);
     }
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/config/ConfigurationException.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/config/ConfigurationException.java
@@ -11,20 +11,21 @@ package io.lighty.core.controller.impl.config;
  * author: vincent on 7.9.2017.
  */
 public class ConfigurationException extends Exception {
+    private static final long serialVersionUID = 1L;
 
     public ConfigurationException() {
         super();
     }
 
-    public ConfigurationException(String s) {
+    public ConfigurationException(final String s) {
         super(s);
     }
 
-    public ConfigurationException(String s, Throwable throwable) {
+    public ConfigurationException(final String s, final Throwable throwable) {
         super(s, throwable);
     }
 
-    public ConfigurationException(Throwable throwable) {
+    public ConfigurationException(final Throwable throwable) {
         super(throwable);
     }
 }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/schema/SchemaServiceProvider.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/schema/SchemaServiceProvider.java
@@ -19,7 +19,6 @@ import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 import org.opendaylight.yangtools.yang.model.api.SchemaContextListener;
 import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
 import org.opendaylight.yangtools.yang.model.repo.api.YangTextSchemaSource;
-import org.opendaylight.yangtools.yang.parser.repo.YangTextSchemaContextResolver;
 
 public class SchemaServiceProvider implements DOMSchemaService, DOMYangTextSourceProvider {
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/services/LightyDiagStatusServiceImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/services/LightyDiagStatusServiceImpl.java
@@ -7,9 +7,8 @@
  */
 package io.lighty.core.controller.impl.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -18,15 +17,23 @@ import org.opendaylight.infrautils.diagstatus.DiagStatusService;
 import org.opendaylight.infrautils.diagstatus.ServiceDescriptor;
 import org.opendaylight.infrautils.diagstatus.ServiceRegistration;
 import org.opendaylight.infrautils.diagstatus.ServiceState;
+import org.opendaylight.infrautils.diagstatus.ServiceStatusSummary;
+import org.opendaylight.infrautils.ready.SystemReadyMonitor;
+import org.opendaylight.infrautils.ready.SystemState;
 
 public class LightyDiagStatusServiceImpl implements DiagStatusService {
 
     private final static String STATE_DESCRIPTION = "Service registration";
 
-    private Map<String, ServiceDescriptor> descriptors = new ConcurrentHashMap<>();
+    private final Map<String, ServiceDescriptor> descriptors = new ConcurrentHashMap<>();
+    private final SystemReadyMonitor systemReadyMonitor;
+
+    public LightyDiagStatusServiceImpl(final SystemReadyMonitor systemReadyMonitor) {
+        this.systemReadyMonitor = requireNonNull(systemReadyMonitor);
+    }
 
     @Override
-    public ServiceRegistration register(String serviceIdentifier) {
+    public ServiceRegistration register(final String serviceIdentifier) {
         final ServiceDescriptor serviceDescriptor = new ServiceDescriptor(serviceIdentifier,
                 ServiceState.STARTING, STATE_DESCRIPTION);
         descriptors.put(serviceIdentifier, serviceDescriptor);
@@ -35,12 +42,12 @@ public class LightyDiagStatusServiceImpl implements DiagStatusService {
     }
 
     @Override
-    public void report(ServiceDescriptor serviceDescriptor) {
+    public void report(final ServiceDescriptor serviceDescriptor) {
         descriptors.put(serviceDescriptor.getModuleServiceName(), serviceDescriptor);
     }
 
     @Override
-    public ServiceDescriptor getServiceDescriptor(String serviceIdentifier) {
+    public ServiceDescriptor getServiceDescriptor(final String serviceIdentifier) {
         return descriptors.get(serviceIdentifier);
     }
 
@@ -54,28 +61,19 @@ public class LightyDiagStatusServiceImpl implements DiagStatusService {
     }
 
     @Override
-    public String getAllServiceDescriptorsAsJSON() {
-        final Collection<ServiceDescriptor> allServiceDescriptors = getAllServiceDescriptors();
-        if (allServiceDescriptors.isEmpty()) {
-            return "{}";
-        } else {
-            ObjectMapper mapper = new ObjectMapper();
-            final ArrayNode arrayNode = mapper.createArrayNode();
-            for (ServiceDescriptor status : allServiceDescriptors) {
-                ObjectNode serviceDescriptor = mapper.createObjectNode();
-                serviceDescriptor.put("serviceName", status.getModuleServiceName());
-                serviceDescriptor.put("effectiveStatus", status.getServiceState().name());
-                serviceDescriptor.put("reportedStatusDescription", status.getStatusDesc());
-                serviceDescriptor.put("statusTimestamp", status.getTimestamp().toString());
-                arrayNode.add(serviceDescriptor);
-            }
-            return arrayNode.toString();
-        }
+    public ServiceStatusSummary getServiceStatusSummary() {
+        SystemState systemState = systemReadyMonitor.getSystemState();
+        Collection<ServiceDescriptor> serviceDescriptors = getAllServiceDescriptors();
+        return new ServiceStatusSummary(isOperational(systemState, serviceDescriptors),
+                systemState, systemReadyMonitor.getFailureCause(), serviceDescriptors);
     }
 
-    @Override
-    public boolean isOperational() {
-        for (ServiceDescriptor sd : getAllServiceDescriptors()) {
+    private static boolean isOperational(final SystemState systemState,
+            final Collection<ServiceDescriptor> serviceDescriptors) {
+        if (!systemState.equals(SystemState.ACTIVE)) {
+            return false;
+        }
+        for (ServiceDescriptor sd : serviceDescriptors) {
             if(sd.getServiceState() != ServiceState.OPERATIONAL) {
                 return false;
             }
@@ -87,7 +85,7 @@ public class LightyDiagStatusServiceImpl implements DiagStatusService {
 
         private final String descriptorId;
 
-        LightyDiagStatusServiceRegistration(String descriptorId) {
+        LightyDiagStatusServiceRegistration(final String descriptorId) {
             this.descriptorId = descriptorId;
         }
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/ControllerConfigUtils.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/ControllerConfigUtils.java
@@ -42,7 +42,7 @@ public final class ControllerConfigUtils {
      */
     public static final Set<YangModuleInfo> YANG_MODELS = ImmutableSet.of(
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.iana.afn.safi.rev130704.$YangModuleInfoImpl.getInstance(),
-            org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.iana._if.type.rev140508.$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.iana._if.type.rev170119.$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.interfaces.rev140508.$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.types.rev130715.$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.rev131019.$YangModuleInfoImpl.getInstance(),

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/SystemReadyMonitorTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/SystemReadyMonitorTest.java
@@ -7,6 +7,9 @@
  */
 package io.lighty.core.controller.api;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import io.lighty.core.controller.impl.services.LightySystemReadyMonitorImpl;
 import org.mockito.Mockito;
 import org.opendaylight.infrautils.ready.SystemReadyListener;
@@ -14,13 +17,10 @@ import org.opendaylight.infrautils.ready.SystemState;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 public class SystemReadyMonitorTest {
 
     @Test
-    public void testSystemBootFailed() {
+    public void testSystemBootFailed() throws Exception {
         SystemReadyListener listener1 = Mockito.mock(SystemReadyListener.class);
         SystemReadyListener listener2 = Mockito.mock(SystemReadyListener.class);
         LightySystemReadyMonitorImpl systemReadyMonitor = new LightySystemReadyMonitorImpl();
@@ -42,7 +42,7 @@ public class SystemReadyMonitorTest {
     }
 
     @Test
-    public void testSystemBootOK() {
+    public void testSystemBootOK() throws Exception {
         SystemReadyListener listener1 = Mockito.mock(SystemReadyListener.class);
         SystemReadyListener listener2 = Mockito.mock(SystemReadyListener.class);
         LightySystemReadyMonitorImpl systemReadyMonitor = new LightySystemReadyMonitorImpl();

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerMountPointTetst.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerMountPointTetst.java
@@ -8,6 +8,7 @@
 package io.lighty.core.controller.impl.tests;
 
 import io.lighty.core.controller.api.LightyController;
+import java.util.Optional;
 import org.opendaylight.mdsal.dom.api.DOMMountPoint;
 import org.opendaylight.mdsal.dom.api.DOMMountPointListener;
 import org.opendaylight.mdsal.dom.api.DOMMountPointService;
@@ -46,16 +47,14 @@ public class LightyControllerMountPointTetst extends LightyControllerTestBase {
         final ObjectRegistration<DOMMountPoint> mountPointRegistration = mountPointBuilder.register();
 
         // 2. get MP from service service
-        final com.google.common.base.Optional<DOMMountPoint> registeredMP = domMountPointService.getMountPoint(
-                testYangIID);
+        final Optional<DOMMountPoint> registeredMP = domMountPointService.getMountPoint(testYangIID);
         Assert.assertTrue(registeredMP.isPresent());
 
         // 3. unregister registered MP
         mountPointRegistration.close();
 
         // 4. check if there isn't registered any MP
-        final com.google.common.base.Optional<DOMMountPoint> unregisterredMP = domMountPointService.getMountPoint(
-                testYangIID);
+        final Optional<DOMMountPoint> unregisterredMP = domMountPointService.getMountPoint(testYangIID);
         Assert.assertFalse(unregisterredMP.isPresent());
 
         // check if MP listener methods were called

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerOldTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerOldTest.java
@@ -8,10 +8,13 @@
 package io.lighty.core.controller.impl.tests;
 
 import io.lighty.core.controller.api.LightyController;
-import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.controller.md.sal.binding.api.DataTreeIdentifier;
+import org.opendaylight.controller.md.sal.binding.api.DataTreeModification;
+import org.opendaylight.controller.md.sal.binding.api.WriteTransaction;
+import org.opendaylight.controller.md.sal.common.api.data.LogicalDatastoreType;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.Topology;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -23,30 +26,21 @@ public class LightyControllerOldTest extends LightyControllerTestBase {
         final CountDownLatch countDownLatch = new CountDownLatch(2);
         final LightyController lightyController = getLightyController();
         final DataBroker bindingDataBroker = lightyController.getServices().getControllerBindingDataBroker();
-        bindingDataBroker.registerDataTreeChangeListener(
-                new org.opendaylight.controller.md.sal.binding.api.DataTreeIdentifier(
-                        org.opendaylight.controller.md.sal.common.api.data.LogicalDatastoreType.OPERATIONAL,
-                        TestUtils.TOPOLOGY_IID),
-                new org.opendaylight.controller.md.sal.binding.api.DataTreeChangeListener<Topology>() {
-
-                    @Override
-                    public void onDataTreeChanged(final Collection<
-                            org.opendaylight.controller.md.sal.binding.api.DataTreeModification<Topology>> changes) {
-                        for (final org.opendaylight.controller.md.sal.binding.api.DataTreeModification<
-                                Topology> change : changes) {
-                            if (countDownLatch.getCount() == 2) {
-                                // on first time - write
-                                Assert.assertNull(change.getRootNode().getDataBefore());
-                                Assert.assertNotNull(change.getRootNode().getDataAfter());
-                            } else if (countDownLatch.getCount() == 1) {
-                                // on second time - delete
-                                Assert.assertNotNull(change.getRootNode().getDataBefore());
-                                Assert.assertNull(change.getRootNode().getDataAfter());
-                            } else {
-                                Assert.fail("Too many DataTreeChange events, expected two");
-                            }
-                            countDownLatch.countDown();
+        bindingDataBroker.registerDataTreeChangeListener(new DataTreeIdentifier<>(LogicalDatastoreType.OPERATIONAL,
+                TestUtils.TOPOLOGY_IID), changes -> {
+                    for (final DataTreeModification<Topology> change : changes) {
+                        if (countDownLatch.getCount() == 2) {
+                            // on first time - write
+                            Assert.assertNull(change.getRootNode().getDataBefore());
+                            Assert.assertNotNull(change.getRootNode().getDataAfter());
+                        } else if (countDownLatch.getCount() == 1) {
+                            // on second time - delete
+                            Assert.assertNotNull(change.getRootNode().getDataBefore());
+                            Assert.assertNull(change.getRootNode().getDataAfter());
+                        } else {
+                            Assert.fail("Too many DataTreeChange events, expected two");
                         }
+                        countDownLatch.countDown();
                     }
                 });
 
@@ -57,11 +51,9 @@ public class LightyControllerOldTest extends LightyControllerTestBase {
         TestUtils.readFromTopology(bindingDataBroker, TestUtils.TOPOLOGY_ID, 1);
 
         // 3. delete from TOPOLOGY model
-        final org.opendaylight.controller.md.sal.binding.api.WriteTransaction deleteTransaction = bindingDataBroker
-                .newWriteOnlyTransaction();
-        deleteTransaction.delete(org.opendaylight.controller.md.sal.common.api.data.LogicalDatastoreType.OPERATIONAL,
-                TestUtils.TOPOLOGY_IID);
-        deleteTransaction.submit().get();
+        final WriteTransaction deleteTransaction = bindingDataBroker.newWriteOnlyTransaction();
+        deleteTransaction.delete(LogicalDatastoreType.OPERATIONAL,TestUtils.TOPOLOGY_IID);
+        deleteTransaction.commit().get();
 
         // 4. read from TOPOLOGY model
         TestUtils.readFromTopology(bindingDataBroker, TestUtils.TOPOLOGY_ID, 0);

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/TestUtils.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/TestUtils.java
@@ -86,12 +86,14 @@ class TestUtils {
 
         final FluentFuture<Optional<NetworkTopology>> upcommingRead = readOnlyTransaction
                 .read(LogicalDatastoreType.OPERATIONAL, networkTopologyInstanceIdentifier);
-        final Optional<NetworkTopology> networkTopologyOptional =
-                upcommingRead.get(40, TimeUnit.MILLISECONDS);
-        final NetworkTopology networkTopology = networkTopologyOptional.get();
-
-        final long count = networkTopology.getTopology().stream()
-                .filter(t -> testTopoId.equals(t.getTopologyId().getValue())).count();
+        final Optional<NetworkTopology> networkTopologyOptional = upcommingRead.get(40, TimeUnit.MILLISECONDS);
+        final long count;
+        if (networkTopologyOptional.isPresent()) {
+            count = networkTopologyOptional.get().nonnullTopology().stream()
+                    .filter(t -> testTopoId.equals(t.getTopologyId().getValue())).count();
+        } else {
+            count = 0;
+        }
         Assert.assertEquals(count, expectedCount);
     }
 
@@ -109,10 +111,14 @@ class TestUtils {
                         networkTopologyInstanceIdentifier);
         final com.google.common.base.Optional<NetworkTopology> networkTopologyOptional = upcommingRead.get(40,
                 TimeUnit.MILLISECONDS);
-        final NetworkTopology networkTopology = networkTopologyOptional.get();
+        final long count;
+        if (networkTopologyOptional.isPresent()) {
+            count = networkTopologyOptional.get().nonnullTopology().stream()
+                    .filter(t -> testTopoId.equals(t.getTopologyId().getValue())).count();
+        } else {
+            count = 0;
+        }
 
-        final long count = networkTopology.getTopology().stream().filter(t -> testTopoId.equals(t.getTopologyId()
-                .getValue())).count();
         Assert.assertEquals(count, expectedCount);
     }
 }

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -38,6 +38,12 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+
+        <!-- ODL components are using JDT annotations quite widely -->
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.annotation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/java/io/lighty/kit/examples/community/aaa/restconf/Main.java
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/java/io/lighty/kit/examples/community/aaa/restconf/Main.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +94,7 @@ public class Main {
         addCallback(startRestconf);
         Security.addProvider(new BouncyCastleProvider());
 
-        final DataBroker bindingDataBroker = lightyController.getServices().getControllerBindingDataBroker();
+        final DataBroker bindingDataBroker = lightyController.getServices().getBindingDataBroker();
         final String moonEndpointPath = "/moon";
         final String oauth2EndpointPath = "/oauth2";
         final String dbUsername = "foo";

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-            <version>9.3.21.v20170918</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -47,18 +47,14 @@ public class RestconfAppTest {
      * Perform basic GET operations via RESTCONF
      */
     @Test
-    public void simpleApplicationTest() {
+    public void simpleApplicationTest() throws TimeoutException, ExecutionException, InterruptedException {
         ContentResponse operations = null;
-        try {
-            operations = restClient.GET("operations");
-            Assert.assertEquals(operations.getStatus(), 200);
-            operations = restClient.GET("data/network-topology:network-topology?content=config");
-            Assert.assertEquals(operations.getStatus(), 200);
-            operations = restClient.GET("data/network-topology:network-topology?content=nonconfig");
-            Assert.assertEquals(operations.getStatus(), 200);
-        } catch (TimeoutException | ExecutionException | InterruptedException e) {
-            Assert.fail();
-        }
+        operations = restClient.GET("operations");
+        Assert.assertEquals(operations.getStatus(), 200);
+        operations = restClient.GET("data/network-topology:network-topology?content=config");
+        Assert.assertEquals(operations.getStatus(), 200);
+        operations = restClient.GET("data/network-topology:network-topology?content=nonconfig");
+        Assert.assertEquals(operations.getStatus(), 200);
     }
 
     @AfterClass

--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/NetconfDeviceRestService.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/NetconfDeviceRestService.java
@@ -80,12 +80,11 @@ public class NetconfDeviceRestService {
                     final NetconfDeviceResponse nodeResponse = NetconfDeviceResponse.from(node);
                     response.add(nodeResponse);
 
-                    final com.google.common.base.Optional<MountPoint> netconfMountPoint =
-                        mountPointService.getMountPoint(NETCONF_TOPOLOGY_IID
+                    final Optional<MountPoint> netconfMountPoint = mountPointService.getMountPoint(NETCONF_TOPOLOGY_IID
                             .child(Node.class, new NodeKey(node.getNodeId())));
 
                     if (netconfMountPoint.isPresent()) {
-                        final com.google.common.base.Optional<DataBroker> netconfDataBroker =
+                        final Optional<DataBroker> netconfDataBroker =
                             netconfMountPoint.get().getService(DataBroker.class);
                         if (netconfDataBroker.isPresent()) {
                             final ReadTransaction netconfReadTx =

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -127,6 +127,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.10</version>

--- a/lighty-modules/lighty-aaa/src/main/java/io/lighty/aaa/AAALighty.java
+++ b/lighty-modules/lighty-aaa/src/main/java/io/lighty/aaa/AAALighty.java
@@ -13,11 +13,10 @@ import io.lighty.server.LightyServerBuilder;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.function.BiConsumer;
 import org.opendaylight.aaa.api.CredentialAuth;
 import org.opendaylight.aaa.api.PasswordCredentials;
 import org.opendaylight.aaa.cert.api.ICertificateManager;
-import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.app.config.rev170619.DatastoreConfig;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.app.config.rev170619.ShiroConfiguration;
 import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
@@ -71,12 +70,9 @@ public final class AAALighty extends AbstractLightyModule {
                 this.moonEndpointPath, this.oauth2EndpointPath, this.datastoreConfig, this.dbUsername, this.dbPassword,
                 this.server);
         final CountDownLatch cdl = new CountDownLatch(1);
-        newInstance.whenComplete(new BiConsumer<AAALightyShiroProvider, Throwable>() {
-            @Override
-            public void accept(final AAALightyShiroProvider t, final Throwable u) {
-                AAALighty.this.aaaShiroProviderHandler.setAaaLightyShiroProvider(t);
-                cdl.countDown();
-            }
+        newInstance.whenComplete((t, u) -> {
+            AAALighty.this.aaaShiroProviderHandler.setAaaLightyShiroProvider(t);
+            cdl.countDown();
         });
         try {
             cdl.await();

--- a/lighty-modules/lighty-aaa/src/main/java/io/lighty/aaa/AAALightyShiroProvider.java
+++ b/lighty-modules/lighty-aaa/src/main/java/io/lighty/aaa/AAALightyShiroProvider.java
@@ -15,6 +15,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtConstructor;
+import javassist.CtMethod;
+import javassist.CtNewConstructor;
+import javassist.CtNewMethod;
+import javassist.NotFoundException;
 import org.apache.shiro.web.env.EnvironmentLoaderListener;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -46,21 +54,13 @@ import org.opendaylight.aaa.shiro.idm.IdmLightProxy;
 import org.opendaylight.aaa.shiro.moon.MoonTokenEndpoint;
 import org.opendaylight.aaa.shiro.oauth2.OAuth2TokenServlet;
 import org.opendaylight.aaa.shiro.tokenauthrealm.auth.AuthenticationManager;
-import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.app.config.rev170619.DatastoreConfig;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.app.config.rev170619.ShiroConfiguration;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.password.service.config.rev170619.PasswordServiceConfig;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.password.service.config.rev170619.PasswordServiceConfigBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javassist.CannotCompileException;
-import javassist.ClassPool;
-import javassist.CtClass;
-import javassist.CtConstructor;
-import javassist.CtMethod;
-import javassist.CtNewConstructor;
-import javassist.CtNewMethod;
-import javassist.NotFoundException;
 
 public final class AAALightyShiroProvider {
 
@@ -92,7 +92,7 @@ public final class AAALightyShiroProvider {
 
         initAAAonServer(server);
         final DefaultPasswordHashService defaultPasswordHashService;
-        if ((datastoreConfig != null) && datastoreConfig.getStore().equals(DatastoreConfig.Store.H2DataStore)) {
+        if (datastoreConfig != null && datastoreConfig.getStore().equals(DatastoreConfig.Store.H2DataStore)) {
             final IdmLightConfig config = new IdmLightConfigBuilder().dbUser(dbUsername).dbPwd(dbPassword).build();
             final PasswordServiceConfig passwordServiceConfig = new PasswordServiceConfigBuilder().setAlgorithm(
                     "SHA-512").setIterations(20000).build();

--- a/lighty-modules/lighty-aaa/src/main/java/io/lighty/aaa/config/CertificateManagerConfig.java
+++ b/lighty-modules/lighty-aaa/src/main/java/io/lighty/aaa/config/CertificateManagerConfig.java
@@ -13,7 +13,7 @@ import org.opendaylight.aaa.cert.api.ICertificateManager;
 import org.opendaylight.aaa.cert.impl.CertificateManagerService;
 import org.opendaylight.aaa.encrypt.AAAEncryptionService;
 import org.opendaylight.aaa.encrypt.impl.AAAEncryptionServiceImpl;
-import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.yang.gen.v1.config.aaa.authn.encrypt.service.config.rev160915.AaaEncryptServiceConfig;
 import org.opendaylight.yang.gen.v1.config.aaa.authn.encrypt.service.config.rev160915.AaaEncryptServiceConfigBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.yang.aaa.cert.rev151126.AaaCertServiceConfig;

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfBaseService.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfBaseService.java
@@ -7,10 +7,10 @@
  */
 package io.lighty.modules.southbound.netconf.impl;
 
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ListenableFuture;
-import org.opendaylight.controller.md.sal.dom.api.DOMRpcResult;
-import org.opendaylight.controller.md.sal.dom.api.DOMService;
+import java.util.Optional;
+import org.opendaylight.mdsal.dom.api.DOMRpcResult;
+import org.opendaylight.mdsal.dom.api.DOMService;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.data.api.ModifyAction;

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfBaseServiceImpl.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfBaseServiceImpl.java
@@ -15,12 +15,12 @@ import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTr
 import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.NETCONF_UNLOCK_QNAME;
 import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.toPath;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfUtils;
-import org.opendaylight.controller.md.sal.dom.api.DOMRpcResult;
-import org.opendaylight.controller.md.sal.dom.api.DOMRpcService;
+import java.util.Optional;
+import org.opendaylight.mdsal.dom.api.DOMRpcResult;
+import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yangtools.yang.common.QName;
@@ -44,7 +44,7 @@ public class NetconfBaseServiceImpl implements NetconfBaseService {
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> get(Optional<YangInstanceIdentifier> filterYII) {
+    public ListenableFuture<DOMRpcResult> get(final Optional<YangInstanceIdentifier> filterYII) {
         if (filterYII.isPresent() && !filterYII.get().isEmpty()) {
             final DataContainerChild<?, ?> filter =
                     NetconfMessageTransformUtil.toFilterStructure(filterYII.get(), schemaContext);
@@ -56,7 +56,7 @@ public class NetconfBaseServiceImpl implements NetconfBaseService {
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> getConfig(QName sourceDatastore, Optional<YangInstanceIdentifier> filterYII) {
+    public ListenableFuture<DOMRpcResult> getConfig(final QName sourceDatastore, final Optional<YangInstanceIdentifier> filterYII) {
         Preconditions.checkNotNull(sourceDatastore);
 
         if (filterYII.isPresent() && !filterYII.get().isEmpty()) {
@@ -73,9 +73,9 @@ public class NetconfBaseServiceImpl implements NetconfBaseService {
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> editConfig(QName targetDatastore, Optional<NormalizedNode<?, ?>> data,
-            YangInstanceIdentifier dataPath, Optional<ModifyAction> dataModifyActionAttribute,
-            Optional<ModifyAction> defaultModifyAction, boolean rollback) {
+    public ListenableFuture<DOMRpcResult> editConfig(final QName targetDatastore, final Optional<NormalizedNode<?, ?>> data,
+            final YangInstanceIdentifier dataPath, final Optional<ModifyAction> dataModifyActionAttribute,
+            final Optional<ModifyAction> defaultModifyAction, final boolean rollback) {
         Preconditions.checkNotNull(targetDatastore);
 
         DataContainerChild<?, ?> editStructure = NetconfUtils.createEditConfigStructure(schemaContext, data,
@@ -88,7 +88,7 @@ public class NetconfBaseServiceImpl implements NetconfBaseService {
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> copyConfig(QName sourceDatastore, QName targetDatastore) {
+    public ListenableFuture<DOMRpcResult> copyConfig(final QName sourceDatastore, final QName targetDatastore) {
         Preconditions.checkNotNull(sourceDatastore);
         Preconditions.checkNotNull(targetDatastore);
 
@@ -98,7 +98,7 @@ public class NetconfBaseServiceImpl implements NetconfBaseService {
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> deleteConfig(QName targetDatastore) {
+    public ListenableFuture<DOMRpcResult> deleteConfig(final QName targetDatastore) {
         Preconditions.checkNotNull(targetDatastore);
         Preconditions.checkArgument(!NETCONF_RUNNING_QNAME.equals(targetDatastore),
                 "Running datastore cannot be deleted.");
@@ -109,14 +109,14 @@ public class NetconfBaseServiceImpl implements NetconfBaseService {
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> lock(QName targetDatastore) {
+    public ListenableFuture<DOMRpcResult> lock(final QName targetDatastore) {
         Preconditions.checkNotNull(targetDatastore);
 
         return domRpcService.invokeRpc(toPath(NETCONF_LOCK_QNAME), NetconfUtils.getLockContent(targetDatastore));
     }
 
     @Override
-    public ListenableFuture<DOMRpcResult> unlock(QName targetDatastore) {
+    public ListenableFuture<DOMRpcResult> unlock(final QName targetDatastore) {
         Preconditions.checkNotNull(targetDatastore);
 
         return domRpcService.invokeRpc(toPath(NETCONF_UNLOCK_QNAME), NetconfUtils.getUnLockContent(targetDatastore));

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
@@ -29,11 +29,10 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
         final SchemaRepositoryProvider schemaRepositoryProvider =
                 new SchemaRepositoryProviderImpl("shared-schema-repository-impl");
         final CallHomeMountDispatcher dispatcher = new CallHomeMountDispatcher(topologyId,
-                lightyServices.getEventExecutor(), lightyServices.getScheduledThreaPool(), lightyServices.getThreadPool(),
-                schemaRepositoryProvider, lightyServices.getControllerBindingDataBroker(), lightyServices
-                .getControllerDOMMountPointService(), encryptionService);
-        this.provider = new IetfZeroTouchCallHomeServerProvider(lightyServices.getControllerBindingDataBroker(),
-                dispatcher);
+            lightyServices.getEventExecutor(), lightyServices.getScheduledThreaPool(), lightyServices.getThreadPool(),
+            schemaRepositoryProvider, lightyServices.getBindingDataBroker(), lightyServices.getDOMMountPointService(),
+            encryptionService);
+        this.provider = new IetfZeroTouchCallHomeServerProvider(lightyServices.getBindingDataBroker(), dispatcher);
     }
 
     @Override

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
@@ -13,9 +13,9 @@ import io.lighty.modules.southbound.netconf.impl.util.NetconfUtils;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.opendaylight.aaa.encrypt.AAAEncryptionService;
-import org.opendaylight.controller.md.sal.dom.api.DOMMountPoint;
-import org.opendaylight.controller.md.sal.dom.api.DOMMountPointService;
-import org.opendaylight.controller.md.sal.dom.api.DOMRpcService;
+import org.opendaylight.mdsal.dom.api.DOMMountPoint;
+import org.opendaylight.mdsal.dom.api.DOMMountPointService;
+import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.netconf.client.NetconfClientDispatcher;
 import org.opendaylight.netconf.topology.api.SchemaRepositoryProvider;
 import org.opendaylight.netconf.topology.impl.NetconfTopologyImpl;
@@ -32,13 +32,13 @@ public class NetconfTopologyPlugin extends AbstractLightyModule implements Netco
             final NetconfClientDispatcher clientDispatcher, final ExecutorService executorService,
             final AAAEncryptionService encryptionService) {
         super(executorService);
-        this.domMountPointService = lightyServices.getControllerDOMMountPointService();
+        this.domMountPointService = lightyServices.getDOMMountPointService();
         final SchemaRepositoryProvider schemaRepositoryProvider =
                 new SchemaRepositoryProviderImpl("shared-schema-repository-impl");
         this.topology = new NetconfTopologyImpl(topologyId, clientDispatcher,
                 lightyServices.getEventExecutor(), lightyServices.getScheduledThreaPool(),
                 lightyServices.getThreadPool(), schemaRepositoryProvider,
-                lightyServices.getControllerBindingDataBroker(), lightyServices.getControllerDOMMountPointService(),
+                lightyServices.getBindingDataBroker(), lightyServices.getDOMMountPointService(),
                 encryptionService, new LightyDeviceActionFactory());
     }
 
@@ -61,10 +61,10 @@ public class NetconfTopologyPlugin extends AbstractLightyModule implements Netco
     @Override
     public Optional<NetconfBaseService> getNetconfBaseService(final NodeId nodeId) {
         final YangInstanceIdentifier yangInstanceIdentifier = NetconfUtils.createNetConfNodeMountPointYII(nodeId);
-        final com.google.common.base.Optional<DOMMountPoint> mountPoint = this.domMountPointService.getMountPoint(yangInstanceIdentifier);
+        final Optional<DOMMountPoint> mountPoint = this.domMountPointService.getMountPoint(yangInstanceIdentifier);
         if (mountPoint.isPresent()) {
             final DOMMountPoint domMountPoint = mountPoint.get();
-            final com.google.common.base.Optional<DOMRpcService> optionalDOMMountPoint = domMountPoint.getService(DOMRpcService.class);
+            final Optional<DOMRpcService> optionalDOMMountPoint = domMountPoint.getService(DOMRpcService.class);
             if (optionalDOMMountPoint.isPresent()) {
                 return Optional.of(new NetconfBaseServiceImpl(nodeId, optionalDOMMountPoint.get(), domMountPoint.getSchemaContext()));
             }

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfUtils.java
@@ -20,10 +20,10 @@ import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTr
 import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.toId;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.util.Optional;
 import org.opendaylight.controller.md.sal.dom.api.DOMRpcResult;
 import org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.netconf.base._1._0.rev110601.copy.config.input.target.ConfigTarget;
@@ -66,7 +66,7 @@ public final class NetconfUtils {
     private NetconfUtils() {
     }
 
-    public static InstanceIdentifier<Node> createNetConfNodeMountPointII(NodeId nodeId) {
+    public static InstanceIdentifier<Node> createNetConfNodeMountPointII(final NodeId nodeId) {
         KeyedInstanceIdentifier<Topology, TopologyKey> instanceIdentifier =
                 InstanceIdentifier.create(NetworkTopology.class).child(Topology.class,
                         new TopologyKey(new TopologyId(TopologyNetconf.QNAME.getLocalName())));
@@ -75,7 +75,7 @@ public final class NetconfUtils {
         return netconfNodeIID;
     }
 
-    public static YangInstanceIdentifier createNetConfNodeMountPointYII(NodeId nodeId) {
+    public static YangInstanceIdentifier createNetConfNodeMountPointYII(final NodeId nodeId) {
         YangInstanceIdentifier yangInstanceIdentifier = YangInstanceIdentifier.builder()
                 .node(NetworkTopology.QNAME)
                 .node(Topology.QNAME)
@@ -97,7 +97,7 @@ public final class NetconfUtils {
             final DataContainerChild<? extends YangInstanceIdentifier.PathArgument, ?> dataNode =
                     ((ContainerNode) result.getResult()).getChild(
                             NetconfMessageTransformUtil.toId(NetconfMessageTransformUtil.NETCONF_DATA_QNAME)).get();
-            return Optional.fromJavaUtil(NormalizedNodes.findNode(dataNode, path.get().getPathArguments()));
+            return NormalizedNodes.findNode(dataNode, path.get().getPathArguments());
         });
     }
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -19,10 +19,10 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.opendaylight.controller.md.sal.dom.api.DOMDataBroker;
-import org.opendaylight.controller.md.sal.dom.api.DOMMountPointService;
-import org.opendaylight.controller.md.sal.dom.api.DOMNotificationService;
-import org.opendaylight.controller.md.sal.dom.api.DOMRpcService;
+import org.opendaylight.mdsal.dom.api.DOMDataBroker;
+import org.opendaylight.mdsal.dom.api.DOMMountPointService;
+import org.opendaylight.mdsal.dom.api.DOMNotificationService;
+import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
 import org.opendaylight.netconf.sal.rest.impl.RestconfApplication;
 import org.opendaylight.netconf.sal.restconf.impl.BrokerFacade;
@@ -196,7 +196,7 @@ public class CommunityRestConf extends AbstractLightyModule {
     }
 
     public void startServer() {
-        if ((this.jettyServer != null) && !this.jettyServer.isStopped()) {
+        if (this.jettyServer != null && !this.jettyServer.isStopped()) {
             return;
         }
         try {

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/config/RestConfConfiguration.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/config/RestConfConfiguration.java
@@ -9,10 +9,10 @@ package io.lighty.modules.northbound.restconf.community.impl.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.net.InetAddress;
-import org.opendaylight.controller.md.sal.dom.api.DOMDataBroker;
-import org.opendaylight.controller.md.sal.dom.api.DOMMountPointService;
-import org.opendaylight.controller.md.sal.dom.api.DOMNotificationService;
-import org.opendaylight.controller.md.sal.dom.api.DOMRpcService;
+import org.opendaylight.mdsal.dom.api.DOMDataBroker;
+import org.opendaylight.mdsal.dom.api.DOMMountPointService;
+import org.opendaylight.mdsal.dom.api.DOMNotificationService;
+import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
 
 public class RestConfConfiguration {
@@ -157,7 +157,7 @@ public class RestConfConfiguration {
         if (this == o) {
             return true;
         }
-        if ((o == null) || (getClass() != o.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
@@ -196,15 +196,15 @@ public class RestConfConfiguration {
     @Override
     public int hashCode() {
         int result = this.domDataBroker.hashCode();
-        result = (31 * result) + this.schemaService.hashCode();
-        result = (31 * result) + this.domRpcService.hashCode();
-        result = (31 * result) + this.domNotificationService.hashCode();
-        result = (31 * result) + this.domMountPointService.hashCode();
-        result = (31 * result) + this.webSocketPort;
-        result = (31 * result) + this.jsonRestconfServiceType.hashCode();
-        result = (31 * result) + this.httpPort;
-        result = (31 * result) + this.restconfServletContextPath.hashCode();
-        result = (31 * result) + this.domSchemaService.hashCode();
+        result = 31 * result + this.schemaService.hashCode();
+        result = 31 * result + this.domRpcService.hashCode();
+        result = 31 * result + this.domNotificationService.hashCode();
+        result = 31 * result + this.domMountPointService.hashCode();
+        result = 31 * result + this.webSocketPort;
+        result = 31 * result + this.jsonRestconfServiceType.hashCode();
+        result = 31 * result + this.httpPort;
+        result = 31 * result + this.restconfServletContextPath.hashCode();
+        result = 31 * result + this.domSchemaService.hashCode();
         return result;
     }
 }

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -102,11 +102,11 @@ public final class RestConfConfigUtils {
             throw new ConfigurationException(String.format("Cannot bind Json tree to type: %s",
                     RestConfConfiguration.class), e);
         }
-        restconfConfiguration.setDomDataBroker(lightyServices.getControllerClusteredDOMDataBroker());
+        restconfConfiguration.setDomDataBroker(lightyServices.getClusteredDOMDataBroker());
         restconfConfiguration.setSchemaService(lightyServices.getDOMSchemaService());
-        restconfConfiguration.setDomRpcService(lightyServices.getControllerDOMRpcService());
-        restconfConfiguration.setDomNotificationService(lightyServices.getControllerDOMNotificationService());
-        restconfConfiguration.setDomMountPointService(lightyServices.getControllerDOMMountPointService());
+        restconfConfiguration.setDomRpcService(lightyServices.getDOMRpcService());
+        restconfConfiguration.setDomNotificationService(lightyServices.getDOMNotificationService());
+        restconfConfiguration.setDomMountPointService(lightyServices.getDOMMountPointService());
         restconfConfiguration.setDomSchemaService(lightyServices.getDOMSchemaService());
 
         return restconfConfiguration;
@@ -121,9 +121,9 @@ public final class RestConfConfigUtils {
      */
     public static RestConfConfiguration getDefaultRestConfConfiguration(final LightyServices lightyServices) {
         return new RestConfConfiguration(
-                lightyServices.getControllerClusteredDOMDataBroker(), lightyServices.getDOMSchemaService(),
-                lightyServices.getControllerDOMRpcService(), lightyServices.getControllerDOMNotificationService(),
-                lightyServices.getControllerDOMMountPointService(), lightyServices.getDOMSchemaService());
+                lightyServices.getClusteredDOMDataBroker(), lightyServices.getDOMSchemaService(),
+                lightyServices.getDOMRpcService(), lightyServices.getDOMNotificationService(),
+                lightyServices.getDOMMountPointService(), lightyServices.getDOMSchemaService());
     }
 
     /**
@@ -148,14 +148,12 @@ public final class RestConfConfigUtils {
     public static RestConfConfiguration getRestConfConfiguration(final RestConfConfiguration restConfConfiguration,
             final LightyServices lightyServices) {
         final RestConfConfiguration config = new RestConfConfiguration(restConfConfiguration);
-        config.setDomDataBroker(lightyServices.getControllerClusteredDOMDataBroker());
+        config.setDomDataBroker(lightyServices.getClusteredDOMDataBroker());
         config.setSchemaService(lightyServices.getDOMSchemaService());
-        config.setDomRpcService(lightyServices.getControllerDOMRpcService());
-        config.setDomNotificationService(lightyServices.getControllerDOMNotificationService());
-        config.setDomMountPointService(lightyServices.getControllerDOMMountPointService());
+        config.setDomRpcService(lightyServices.getDOMRpcService());
+        config.setDomNotificationService(lightyServices.getDOMNotificationService());
+        config.setDomMountPointService(lightyServices.getDOMMountPointService());
         config.setDomSchemaService(lightyServices.getDOMSchemaService());
         return config;
     }
-
-
 }


### PR DESCRIPTION
odlparent-4.0.9, yangtools-2.1.8 and mdsal-3.0.6, with other
components going to current SNAPSHOT versions.

Also adjusts for API changes in mdsal and infrautils, as well as
for empty lists disappearing.

NETCONF/AAA/RESTCONF wiring is updated to reflect these components
using MD-SAL APIs instead of the Controller APIs.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>