### PR TITLE
Fix issue #147

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -92,7 +92,7 @@
                     <configuration>
                         <forkCount>1</forkCount>
                         <reuseForks>true</reuseForks>
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <excludes>
                             <exclude>**/*TestIT.java</exclude>
                         </excludes>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -85,5 +85,22 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                    <configuration>
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <excludes>
+                            <exclude>**/*TestIT.java</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
Redirect surefire-plugin test output
'/target/surefire-reports/TestName-output.txt'
Delete surefire-plugin memory limits.

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>