### PR TITLE
Copy only runtime dependencies.

### DIFF
--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -127,6 +127,7 @@
                                     <goal>copy-dependencies</goal>
                                 </goals>
                                 <configuration>
+                                    <includeScope>runtime</includeScope>
                                     <outputDirectory>${project.build.directory}/lib</outputDirectory>
                                     <silent>${lighty.silent.unpack}</silent>
                                 </configuration>


### PR DESCRIPTION
Added scope for copy only runtime dependencies to target/lib.
As a default is set to all, include test dependencies.

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>