### PR TITLE
9.2.x Add Postman collection to OFP and fix main example.

### DIFF
--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/OFP_postman_collection.json
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/OFP_postman_collection.json
@@ -1,0 +1,497 @@
+{
+	"info": {
+		"_postman_id": "ef51dd9f-e393-4ed7-8bdc-e0f1dfac43b6",
+		"name": "Lighty OFP",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get entity-owners",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8888/restconf/data/entity-owners:entity-owners",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"entity-owners:entity-owners"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get openflow:1",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8888/restconf/data/opendaylight-inventory:nodes/node=openflow%3A1",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes",
+						"node=openflow%3A1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get openflow:1 operational",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8888/restconf/data/opendaylight-inventory:nodes/node=openflow%3A1?content=nonconfig",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes",
+						"node=openflow%3A1"
+					],
+					"query": [
+						{
+							"key": "content",
+							"value": "nonconfig"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get inventory",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8888/restconf/data/opendaylight-inventory:nodes",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add table-miss flow",
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/xml",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<flow xmlns=\"urn:opendaylight:flow:inventory\">\n   <barrier>false</barrier>\n   <cookie>54</cookie>\n   <flags>SEND_FLOW_REM</flags>\n   <flow-name>FooXf54</flow-name>\n   <hard-timeout>0</hard-timeout>\n   <id>1</id>\n   <idle-timeout>0</idle-timeout>\n   <installHw>false</installHw>\n   <instructions>\n       <instruction>\n           <apply-actions>\n               <action>\n                   <output-action>\n                       <max-length>65535</max-length>\n                       <output-node-connector>CONTROLLER</output-node-connector>\n                   </output-action>\n                   <order>0</order>\n               </action>\n           </apply-actions>\n           <order>0</order>\n       </instruction>\n   </instructions>\n   <match/>\n   <priority>0</priority>\n   <strict>false</strict>\n   <table_id>0</table_id>\n</flow>"
+				},
+				"url": {
+					"raw": "http://localhost:8888/restconf/data/opendaylight-inventory:nodes/node=openflow%3A1/table=0/flow=1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes",
+						"node=openflow%3A1",
+						"table=0",
+						"flow=1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add RPC table-miss flow",
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"input\": {\n      \"opendaylight-flow-service:node\":\"/opendaylight-inventory:nodes/opendaylight-inventory:node[opendaylight-inventory:id='openflow:1']\",\n      \"priority\": 0,\n      \"table_id\": 0,\n      \"instructions\": {\n        \"instruction\": [\n          {\n            \"order\": 0,\n            \"apply-actions\": {\n              \"action\": [\n                {\n                  \"order\": 0,\n                  \"output-action\": {\n                    \"max-length\": \"65535\",\n                    \"output-node-connector\": \"CONTROLLER\"\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      },\n      \"match\": {\n      }\n    }\n}\n"
+				},
+				"url": {
+					"raw": "http://localhost:8888/restconf/operations/sal-flow:add-flow",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"operations",
+						"sal-flow:add-flow"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get table-miss flow",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8888/restconf/data/opendaylight-inventory:nodes/node=openflow%3A1/table=0",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes",
+						"node=openflow%3A1",
+						"table=0"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get table-miss flow Operational",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8888/restconf/data/opendaylight-inventory:nodes/node=openflow%3A1/table=0?content=nonconfig",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes",
+						"node=openflow%3A1",
+						"table=0"
+					],
+					"query": [
+						{
+							"key": "content",
+							"value": "nonconfig"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete RPC table-miss flow",
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"input\": {\n      \"opendaylight-flow-service:node\":\"/opendaylight-inventory:nodes/opendaylight-inventory:node[opendaylight-inventory:id='openflow:1']\",\n      \"table_id\": 0\n    }\n}\n"
+				},
+				"url": {
+					"raw": "http://localhost:8888/restconf/operations/sal-flow:remove-flow",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"operations",
+						"sal-flow:remove-flow"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete table-miss flow",
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/xml",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8888/restconf/data/opendaylight-inventory:nodes/node=openflow%3A1/table=0/flow=1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8888",
+					"path": [
+						"restconf",
+						"data",
+						"opendaylight-inventory:nodes",
+						"node=openflow%3A1",
+						"table=0",
+						"flow=1"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
@@ -100,14 +100,14 @@ public class Main {
         final LightyController lightyController = lightyControllerBuilder.from(controllerConfiguration).build();
         lightyController.start().get();
 
-        //2. start Restconf server
+        //2. start RestConf server
         final CommunityRestConfBuilder communityRestConfBuilder = new CommunityRestConfBuilder();
         final CommunityRestConf communityRestConf = communityRestConfBuilder.from(RestConfConfigUtils
                 .getRestConfConfiguration(restConfConfiguration, lightyController.getServices()))
                 .build();
         communityRestConf.start();
 
-        //3. start openflow SBP
+        //3. start OpenFlow SBP
         final OpenflowSouthboundPlugin plugin;
         plugin = new OpenflowSouthboundPluginBuilder()
                 .from(configuration, lightyController.getServices())
@@ -131,7 +131,7 @@ public class Main {
             }
         }, Executors.newSingleThreadExecutor());
 
-        shutdownHook = new ShutdownHook(lightyController, communityRestConf, null);
+        shutdownHook = new ShutdownHook(lightyController, communityRestConf, plugin);
         Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 

--- a/lighty-modules/lighty-openflow-sb/pom.xml
+++ b/lighty-modules/lighty-openflow-sb/pom.xml
@@ -78,6 +78,7 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
Add Postman collection.
Add OFP instance as a ShutdownHook parameter.
Add forgotten test scope to OFP pom.

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>