### PR TITLE
9.2.x Add PacketInListener to main class of OFP example

### DIFF
--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
@@ -111,6 +111,7 @@ public class Main {
         final OpenflowSouthboundPlugin plugin;
         plugin = new OpenflowSouthboundPluginBuilder()
                 .from(configuration, lightyController.getServices())
+                .withPacketListener(new PacketInListener())
                 .build();
         ListenableFuture<Boolean> start = plugin.start();
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/PacketInListener.java
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/PacketInListener.java
@@ -1,6 +1,5 @@
 package io.lighty.examples.controllers.restconf.ofp;
 
-import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketIn;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketProcessingListener;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketReceived;
 import org.slf4j.Logger;
@@ -15,8 +14,6 @@ public class PacketInListener implements PacketProcessingListener {
 
     @Override
     public void onPacketReceived(PacketReceived notification) {
-        if (notification instanceof PacketIn) {
-            LOG.trace("PacketIn Recived.",notification);
-        }
+        LOG.trace("PacketIn Recived. {}", notification);
     }
 }

--- a/lighty-examples/lighty-community-restconf-ofp-ovsdb-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-ofp-ovsdb-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -123,7 +123,7 @@
     "frmStaleMarkingEnabled": false,
     "frmReconciliationRetryCount": 5,
     "frmBundleBasedReconciliationEnabled": false,
-    "stateful": true,
+    "enableForwardingRulesManager": true,
     "switchConfig": {
       "instanceName": "openflow-switch-connection-provider-default-impl",
       "port": 6653,

--- a/lighty-examples/lighty-community-restconf-ofp-ovsdb-app/src/main/java/io/lighty/examples/controllers/restconf/ofpovsdb/PacketInListener.java
+++ b/lighty-examples/lighty-community-restconf-ofp-ovsdb-app/src/main/java/io/lighty/examples/controllers/restconf/ofpovsdb/PacketInListener.java
@@ -1,6 +1,5 @@
 package io.lighty.examples.controllers.restconf.ofpovsdb;
 
-import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketIn;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketProcessingListener;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketReceived;
 import org.slf4j.Logger;
@@ -15,8 +14,6 @@ public class PacketInListener implements PacketProcessingListener {
 
     @Override
     public void onPacketReceived(PacketReceived notification) {
-        if (notification instanceof PacketIn) {
-            LOG.trace("PacketIn Recived.",notification);
-        }
+        LOG.trace("PacketIn Recived. {}", notification);
     }
 }


### PR DESCRIPTION
Delete unnecessary if condition in PacketInListener.
Change in OFP+OVSDB example sampleConfigSingleNode.json from 'stateful' to 'enableForwardingRulesManager'.