### PR TITLE
9.2.x Update README and add dependency

### DIFF
--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>9.1.1</version>
+    <version>9.2.0</version>
   </dependency>
 ```
 
@@ -25,10 +25,10 @@ To use Lighty controller in your project:
 ```
   ControllerConfiguration defaultSingleNodeConfiguration
      = ControllerConfigUtils.getDefaultSingleNodeConfiguration();
-  ODLController odlController = new ODLControllerBuilder()
-     .from(controllerConfiguration)
+  LightyController lightyController = new LightyControllerBuilder()
+     .from(defaultSingleNodeConfiguration)
      .build();
-  odlController.start();
+  lightyController.start();
 ```
 
 3. Use LightyServices in your application

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>lighty-controller</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
             <scope>test</scope>

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>9.1.1</version>
+    <version>9.2.0</version>
   </dependency>
 ```
 
@@ -20,10 +20,10 @@ To use RESTCONF in your project:
 ```
   RestConfConfiguration restConfConfig
       = RestConfConfigUtils.getDefaultRestConfConfiguration();
-  ODLRestConf odlRestConf = new ODLRestConfBuilder()
-      .from(RestConfConfigUtils.getRestConfConfiguration(restConfConfig, odlController.getServices()))
+  CommunityRestConf communityRestConf = new CommunityRestConfBuilder()
+      .from(restConfConfig)
       .build();
-  odlRestConf.start();
+  communityRestConf.start();
 ```
 
 ## Configuration


### PR DESCRIPTION
Add missing jersey-hk2 dependency to integration-tests.
Update README in lighty-restconf-nb-community.
Update README in lighty-controller.