### PR TITLE
Bump upstream references to Neon SR1

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>4.0.9</version>
+                <version>4.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,56 +42,56 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.9.0</version>
+                <version>0.9.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>config-artifacts</artifactId>
-                <version>0.10.0</version>
+                <version>0.10.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>1.9.0</version>
+                <version>1.9.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.5.0</version>
+                <version>1.5.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>3.0.6</version>
+                <version>3.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.6.0</version>
+                <version>1.6.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>restconf-artifacts</artifactId>
-                <version>1.9.0</version>
+                <version>1.9.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>2.1.8</version>
+                <version>2.1.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -99,24 +99,27 @@
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.openflowplugin.applications</groupId>
                 <artifactId>arbitratorreconciliation-impl</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.1</version>
             </dependency>
+
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
-                <artifactId>srm-api</artifactId>
-                <version>0.3.0</version>
+                <artifactId>serviceutils-artifacts</artifactId>
+                <version>0.3.1</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>srm-impl</artifactId>
-                <version>0.3.0</version>
+                <version>0.3.1</version>
             </dependency>
 
             <!-- Other third-party stuff -->

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -51,12 +51,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>2.1.8</version>
+                <version>2.1.10</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>1.0.6</version>
+                        <version>1.0.8</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
This adjust upstream dependencies to Neon SR1, removing duplicate
artifact declarations.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>