### PR TITLE
Bump yangtools/mdsal to 3.0.1/4.0.2

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>4.0.0</version>
+                <version>4.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -91,7 +91,7 @@
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -317,10 +317,6 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-connector-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-inmemory-datastore</artifactId>
         </dependency>
         <!--odl-akka-scala-2.12-->


### PR DESCRIPTION
This brings the versions up to speed with current Sodium status
of affairs.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>