### PR TITLE
Fix build jobs to run on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: trusty
 language: java
 
 jdk:
- - oraclejdk8
+ - openjdk8
  - oraclejdk11
 
 before_install:


### PR DESCRIPTION
Xenial does not seem to like oraclejdk8, let's stick with trusty.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>