### PR TITLE
Reduce JSR305 proliferation

### DIFF
--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -36,12 +36,15 @@
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>yang-binding</artifactId>
         </dependency>
-        <!-- Oxygen v1 generator needs javax.annotation.CheckReturnValue for RPCs. -->
-        <!-- spotbugs should be used instead of findbugs -->
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.1</version>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.annotation</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -36,12 +36,6 @@
             <artifactId>lighty-common</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.1</version>
-        </dependency>
-
         <!--ODL-->
         <!--odl-guava-22-->
         <dependency>

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -16,7 +16,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,7 +139,7 @@ public abstract class AbstractLightyModule implements LightyModule {
     public void startBlocking(Consumer<Boolean> initFinishCallback) throws InterruptedException {
         Futures.addCallback(start(), new FutureCallback<Boolean>() {
             @Override
-            public void onSuccess(@Nullable Boolean result) {
+            public void onSuccess(Boolean result) {
                 initFinishCallback.accept(true);
             }
 

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerNotificationTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerNotificationTest.java
@@ -10,7 +10,6 @@ package io.lighty.core.controller.impl.tests;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.lighty.core.controller.api.LightyController;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
 import org.opendaylight.mdsal.dom.api.DOMNotification;
 import org.opendaylight.mdsal.dom.api.DOMNotificationPublishService;
 import org.opendaylight.mdsal.dom.api.DOMNotificationService;
@@ -29,13 +28,11 @@ public class LightyControllerNotificationTest extends LightyControllerTestBase {
         // setup
         final SchemaPath schemaPath = SchemaPath.ROOT;
         final DOMNotification testNotification = new DOMNotification() {
-            @Nonnull
             @Override
             public SchemaPath getType() {
                 return schemaPath;
             }
 
-            @Nonnull
             @Override
             public ContainerNode getBody() {
                 return ImmutableContainerNodeBuilder.create().build();

--- a/lighty-modules/lighty-openflow-sb/pom.xml
+++ b/lighty-modules/lighty-openflow-sb/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>openflow-protocol-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.opendaylight.openflowplugin</groupId>
             <artifactId>openflowplugin-extension-api</artifactId>
         </dependency>


### PR DESCRIPTION
JSR305 is no longer a core dependency of ODL, hence we can actively
reduce our proliferation of it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>