### PR TITLE
Remove DOMYangTextSourceProvider wiring

### DIFF
--- a/lighty-core/lighty-controller-guice-di/src/main/java/io/lighty/core/controller/guice/LightyControllerModule.java
+++ b/lighty-core/lighty-controller-guice-di/src/main/java/io/lighty/core/controller/guice/LightyControllerModule.java
@@ -38,7 +38,6 @@ import org.opendaylight.mdsal.dom.api.DOMNotificationService;
 import org.opendaylight.mdsal.dom.api.DOMRpcProviderService;
 import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
-import org.opendaylight.mdsal.dom.api.DOMYangTextSourceProvider;
 import org.opendaylight.mdsal.dom.spi.DOMNotificationSubscriptionListenerRegistry;
 import org.opendaylight.mdsal.eos.binding.api.EntityOwnershipService;
 import org.opendaylight.mdsal.eos.dom.api.DOMEntityOwnershipService;
@@ -74,8 +73,6 @@ public class LightyControllerModule extends AbstractModule {
                 .toInstance(lightyServices.getSchemaContextProvider());
         bind(DOMSchemaService.class)
                 .toInstance(lightyServices.getDOMSchemaService());
-        bind(DOMYangTextSourceProvider.class)
-                .toInstance(lightyServices.getDOMYangTextSourceProvider());
         bind(DOMNotificationSubscriptionListenerRegistry.class)
                 .toInstance(lightyServices.getDOMNotificationSubscriptionListenerRegistry());
         bind(DistributedDataStoreInterface.class)

--- a/lighty-core/lighty-controller-spring-di/src/main/java/io/lighty/core/controller/spring/LightyCoreSpringConfiguration.java
+++ b/lighty-core/lighty-controller-spring-di/src/main/java/io/lighty/core/controller/spring/LightyCoreSpringConfiguration.java
@@ -34,7 +34,6 @@ import org.opendaylight.mdsal.dom.api.DOMNotificationService;
 import org.opendaylight.mdsal.dom.api.DOMRpcProviderService;
 import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
-import org.opendaylight.mdsal.dom.api.DOMYangTextSourceProvider;
 import org.opendaylight.mdsal.dom.spi.DOMNotificationSubscriptionListenerRegistry;
 import org.opendaylight.mdsal.eos.binding.api.EntityOwnershipService;
 import org.opendaylight.mdsal.eos.dom.api.DOMEntityOwnershipService;
@@ -101,11 +100,6 @@ public class LightyCoreSpringConfiguration {
     @Bean(destroyMethod = "")
     public DOMSchemaService getDOMSchemaService() {
         return this.lightyController.getServices().getDOMSchemaService();
-    }
-
-    @Bean(destroyMethod = "")
-    public DOMYangTextSourceProvider getDOMYangTextSourceProvider() {
-        return this.lightyController.getServices().getDOMYangTextSourceProvider();
     }
 
     @Bean(destroyMethod = "")

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyServices.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyServices.java
@@ -37,7 +37,6 @@ import org.opendaylight.mdsal.dom.api.DOMNotificationService;
 import org.opendaylight.mdsal.dom.api.DOMRpcProviderService;
 import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
-import org.opendaylight.mdsal.dom.api.DOMYangTextSourceProvider;
 import org.opendaylight.mdsal.dom.spi.DOMNotificationSubscriptionListenerRegistry;
 import org.opendaylight.mdsal.eos.binding.api.EntityOwnershipService;
 import org.opendaylight.mdsal.eos.dom.api.DOMEntityOwnershipService;
@@ -64,8 +63,6 @@ public interface LightyServices extends LightyModuleRegistryService {
     SchemaContextProvider getSchemaContextProvider();
 
     DOMSchemaService getDOMSchemaService();
-
-    DOMYangTextSourceProvider getDOMYangTextSourceProvider();
 
     DOMNotificationSubscriptionListenerRegistry getDOMNotificationSubscriptionListenerRegistry();
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -86,7 +86,6 @@ import org.opendaylight.mdsal.dom.api.DOMNotificationService;
 import org.opendaylight.mdsal.dom.api.DOMRpcProviderService;
 import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
-import org.opendaylight.mdsal.dom.api.DOMYangTextSourceProvider;
 import org.opendaylight.mdsal.dom.broker.DOMMountPointServiceImpl;
 import org.opendaylight.mdsal.dom.broker.DOMNotificationRouter;
 import org.opendaylight.mdsal.dom.broker.DOMRpcRouter;
@@ -425,11 +424,6 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     @Override
     public DOMSchemaService getDOMSchemaService() {
         return this.schemaService;
-    }
-
-    @Override
-    public DOMYangTextSourceProvider getDOMYangTextSourceProvider() {
-        return getDOMSchemaService().getExtensions().getInstance(DOMYangTextSourceProvider.class);
     }
 
     @Override

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTest.java
@@ -26,7 +26,6 @@ public class LightyControllerTest extends LightyControllerTestBase {
         Assert.assertNotNull(lightyController.getServices().getActorSystemProvider().getActorSystem());
         Assert.assertNotNull(lightyController.getServices().getSchemaContextProvider());
         Assert.assertNotNull(lightyController.getServices().getDOMSchemaService());
-        Assert.assertNotNull(lightyController.getServices().getDOMYangTextSourceProvider());
         Assert.assertNotNull(lightyController.getServices().getDOMNotificationSubscriptionListenerRegistry());
         Assert.assertNotNull(lightyController.getServices().getConfigDatastore());
         Assert.assertNotNull(lightyController.getServices().getOperationalDatastore());


### PR DESCRIPTION
DOMYangTextSourceProvider is a DOMSchemaServiceExtension and should
be acquired through DOMSchemaService.getExtensions().getInstance()
when really needed. Remove it from wiring.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>