### PR TITLE
Fix sonar bug reports in lighty-codecs

### DIFF
--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
@@ -144,7 +144,7 @@ public class DataCodec<T extends DataObject> implements Codec<T> {
     public NormalizedNode<?, ?> serializeXMLError(final String body) {
         final Optional<Revision> restconfRevision = Revision.ofNullable("2017-01-26");
         final Module restconfModule = this.schemaContext.findModule("ietf-restconf", restconfRevision)
-                .get();
+                .orElseThrow(() -> new IllegalStateException("ietf-restconf module was not found in schema context."));
         final List<UnknownSchemaNode> unknownSchemaNodes = restconfModule.getUnknownSchemaNodes();
         final QNameModule qNameRestconfModule = QNameModule
                 .create(URI.create("urn:ietf:params:xml:ns:yang:ietf-restconf"), restconfRevision);
@@ -153,14 +153,13 @@ public class DataCodec<T extends DataObject> implements Codec<T> {
                 (YangDataSchemaNode) unknownSchemaNodes.stream()
                         .filter(unknownSchemaNode -> yangDataYangErrors.equals(unknownSchemaNode.getQName()))
                         .findFirst()
-                        .get();
+                        .orElseThrow(() -> new IllegalStateException("node yang-error wasn't found in ietf-restconf "));
 
         final DataSchemaNode schemaNode = yangDataNode.getContainerSchemaNode();
         final NormalizedNodeResult resultHolder = new NormalizedNodeResult();
         final NormalizedNodeStreamWriter writer = ImmutableNormalizedNodeStreamWriter.from(resultHolder);
-        final XmlParserStream xmlParser = XmlParserStream.create(writer, this.schemaContext, schemaNode);
 
-        try {
+        try (final XmlParserStream xmlParser = XmlParserStream.create(writer, this.schemaContext, schemaNode)) {
             final Document doc = XmlUtil.readXmlToDocument(body);
             final XmlElement element = XmlElement.fromDomDocument(doc);
             final Element domElement = element.getDomElement();

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
@@ -45,7 +45,6 @@ public final class XmlUtil {
     public static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/";
     private static final DocumentBuilderFactory BUILDER_FACTORY;
     private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
-    private static final SchemaFactory SCHEMA_FACTORY = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
     static {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -199,7 +198,7 @@ public final class XmlUtil {
         }
 
         try {
-            return SCHEMA_FACTORY.newSchema(sources);
+            return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(sources);
         } catch (final SAXException e) {
             throw new IllegalStateException("Failed to instantiate XML schema", e);
         }


### PR DESCRIPTION
Fix sonar bug reports in lighty-codecs:
- secure Optional.get() calls by adding orElseThrow()
- remove static attribut SchemaFactory

Signed-off-by: Tibor Král <tibor.kral@pantheon.tech>