### PR TITLE
Move DOMNotificationRouter instantiation to constructor

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerBuilder.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerBuilder.java
@@ -54,15 +54,14 @@ public class LightyControllerBuilder {
     public LightyController build() throws ConfigurationException {
         try {
             final Set<YangModuleInfo> modelSet = this.controllerConfiguration.getSchemaServiceConfig().getModels();
-            final DOMNotificationRouter domNotificationRouter = DOMNotificationRouter.create(
-                    this.controllerConfiguration.getDomNotificationRouterConfig().getQueueDepth(),
-                    this.controllerConfiguration.getDomNotificationRouterConfig().getSpinTime(),
-                    this.controllerConfiguration.getDomNotificationRouterConfig().getParkTime(),
-                    this.controllerConfiguration.getDomNotificationRouterConfig().getUnit());
             return new LightyControllerImpl(this.executorService,
                     this.controllerConfiguration.getActorSystemConfig().getConfig(),
                     this.controllerConfiguration.getActorSystemConfig().getClassLoader(),
-                    domNotificationRouter,
+                    DOMNotificationRouter.create(
+                            this.controllerConfiguration.getDomNotificationRouterConfig().getQueueDepth(),
+                            this.controllerConfiguration.getDomNotificationRouterConfig().getSpinTime(),
+                            this.controllerConfiguration.getDomNotificationRouterConfig().getParkTime(),
+                            this.controllerConfiguration.getDomNotificationRouterConfig().getUnit()),
                     this.controllerConfiguration.getRestoreDirectoryPath(),
                     this.controllerConfiguration.getMaxDataBrokerFutureCallbackQueueSize(),
                     this.controllerConfiguration.getMaxDataBrokerFutureCallbackPoolSize(),


### PR DESCRIPTION
Move DOMNotificationRouter instantiation directly to LightyController constructor call

Signed-off-by: Tibor Král <tibor.kral@pantheon.tech>