### PR TITLE
Bump versions for 9.3.x

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>3.1.6</version>
+                <version>3.1.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,89 +42,89 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>config-artifacts</artifactId>
-                <version>0.9.2</version>
+                <version>0.9.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>1.8.2</version>
+                <version>1.8.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.4.2</version>
+                <version>1.4.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>2.5.2</version>
+                <version>2.5.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal.model</groupId>
                 <artifactId>mdsal-model-artifacts</artifactId>
-                <version>0.13.2</version>
+                <version>0.13.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.5.2</version>
+                <version>1.5.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>restconf-artifacts</artifactId>
-                <version>1.8.2</version>
+                <version>1.8.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>2.0.16</version>
+                <version>2.0.20</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.ovsdb</groupId>
                 <artifactId>southbound-artifacts</artifactId>
-                <version>1.7.1</version>
+                <version>1.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.7.1</version>
+                <version>0.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.openflowplugin.applications</groupId>
                 <artifactId>arbitratorreconciliation-impl</artifactId>
-                <version>0.7.1</version>
+                <version>0.7.3</version>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>srm-impl</artifactId>
-                <version>0.2.1</version>
+                <version>0.2.3</version>
             </dependency>
 
             <!-- Other third-party stuff -->

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>dependency-versions</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -51,12 +51,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>2.0.16</version>
+                <version>2.0.20</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>0.13.2</version>
+                        <version>0.13.3</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-bom</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,98 +26,98 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-codecs</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-common</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- DI framework integrations -->
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-guice-di</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-spring-di</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Modules -->
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-aaa</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-jetty-server</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-netconf-sb</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-restconf-nb-community</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-swagger</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-openflow-sb</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-ovsdb-sb</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Utility resources -->
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>controller-application-assembly</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>singlenode-configuration</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Dependencies and resources which should not normally leak into production -->
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-test-models</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-toaster</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>log4j-properties</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-guice-di/pom.xml
+++ b/lighty-core/lighty-controller-guice-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-minimal-parent</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,14 +29,14 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>dependency-versions</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-minimal-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../lighty-minimal-parent</relativePath>
     </parent>
 

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-core-aggregator</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-community-aaa-restconf-app</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-ofp-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-community-restconf-ofp-ovsdb-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-ofp-ovsdb-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-ovsdb-sb</artifactId>
-            <!--<version>9.2.1-SNAPSHOT</version>-->
+            <!--<version>9.3.0-SNAPSHOT</version>-->
         </dependency>
     </dependencies>
 </project>

--- a/lighty-examples/lighty-community-restconf-ovsdb-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-ovsdb-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller-springboot</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Demo lighty.io project for SpringBoot</description>
 
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>9.2.1-SNAPSHOT</version>
+                <version>9.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-examples/pom.xml
+++ b/lighty-examples/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.kit.examples</groupId>
     <artifactId>example-applications-aggregator</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/pom.xml
+++ b/lighty-models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/test/lighty-example-data-center/pom.xml
+++ b/lighty-models/test/lighty-example-data-center/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-test-models/pom.xml
+++ b/lighty-models/test/lighty-test-models/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-toaster/pom.xml
+++ b/lighty-models/test/lighty-toaster/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/pom.xml
+++ b/lighty-models/test/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models.test</groupId>
     <artifactId>lighty-models-test-aggregator</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-openflow-sb/pom.xml
+++ b/lighty-modules/lighty-openflow-sb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-openflow-sb/src/main/java/io/lighty/modules/southbound/openflow/impl/OpenflowSouthboundPlugin.java
+++ b/lighty-modules/lighty-openflow-sb/src/main/java/io/lighty/modules/southbound/openflow/impl/OpenflowSouthboundPlugin.java
@@ -12,6 +12,10 @@ import io.lighty.core.controller.api.LightyServices;
 import io.lighty.modules.southbound.openflow.impl.config.ConfigurationServiceFactory;
 import io.lighty.modules.southbound.openflow.impl.config.OpenflowpluginConfiguration;
 import io.lighty.modules.southbound.openflow.impl.config.SwitchConfig;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.opendaylight.openflowjava.protocol.spi.connection.SwitchConnectionProvider;
 import org.opendaylight.openflowplugin.api.diagstatus.OpenflowPluginDiagStatusProvider;
 import org.opendaylight.openflowplugin.api.openflow.OpenFlowPluginProvider;
@@ -39,10 +43,6 @@ import org.opendaylight.yangtools.concepts.ListenerRegistration;
 import org.opendaylight.yangtools.yang.binding.NotificationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 public class OpenflowSouthboundPlugin extends AbstractLightyModule implements OpenflowServices {
 
@@ -66,7 +66,7 @@ public class OpenflowSouthboundPlugin extends AbstractLightyModule implements Op
         super(executorService);
 
         this.lightyServices = lightyServices;
-        this.providers = new SwitchConfig().getDefaultProviders();
+        this.providers = new SwitchConfig().getDefaultProviders(lightyServices.getDiagStatusService());
         this.configurationService = new ConfigurationServiceFactory().newInstance(new OpenflowpluginConfiguration()
                 .getDefaultProviderConfig());
     }
@@ -203,7 +203,7 @@ public class OpenflowSouthboundPlugin extends AbstractLightyModule implements Op
      * Start close() method in AutoCloseable instance
      * @param instance instance of {@link AutoCloseable}
      */
-    private void destroy(AutoCloseable instance){
+    private void destroy(final AutoCloseable instance){
         if (instance != null) {
             try {
                 instance.close();

--- a/lighty-modules/lighty-openflow-sb/src/main/java/io/lighty/modules/southbound/openflow/impl/OpenflowSouthboundPluginBuilder.java
+++ b/lighty-modules/lighty-openflow-sb/src/main/java/io/lighty/modules/southbound/openflow/impl/OpenflowSouthboundPluginBuilder.java
@@ -11,9 +11,9 @@ import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.api.LightyServices;
 import io.lighty.modules.southbound.openflow.impl.config.OpenflowpluginConfiguration;
 import io.lighty.modules.southbound.openflow.impl.config.SwitchConfig;
+import java.util.concurrent.ExecutorService;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketProcessingListener;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.openflowplugin.app.forwardingrules.manager.config.rev160511.ForwardingRulesManagerConfigBuilder;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Builder for {@link OpenflowSouthboundPlugin}.
@@ -35,8 +35,8 @@ public class OpenflowSouthboundPluginBuilder {
      * @return instance of {@link OpenflowSouthboundPluginBuilder}.
      */
     public OpenflowSouthboundPluginBuilder from(
-            OpenflowpluginConfiguration openflowpluginConfiguration,
-            LightyServices lightyServices) {
+            final OpenflowpluginConfiguration openflowpluginConfiguration,
+            final LightyServices lightyServices) {
         this.ofpConfiguration = openflowpluginConfiguration;
         this.switchConnectionProviders = openflowpluginConfiguration.getSwitchConfig();
         this.lightyServices = lightyServices;
@@ -48,7 +48,7 @@ public class OpenflowSouthboundPluginBuilder {
      * @param executorService instance of {@link ExecutorService}.
      * @return instance of {@link OpenflowSouthboundPluginBuilder}.
      */
-    public OpenflowSouthboundPluginBuilder withExecutorService(ExecutorService executorService) {
+    public OpenflowSouthboundPluginBuilder withExecutorService(final ExecutorService executorService) {
         this.executorService = executorService;
         return this;
     }
@@ -58,7 +58,7 @@ public class OpenflowSouthboundPluginBuilder {
      * @param ofpPacketListener instance of {@link PacketProcessingListener}.
      * @return instance of {@link OpenflowSouthboundPluginBuilder}.
      */
-    public OpenflowSouthboundPluginBuilder withPacketListener(PacketProcessingListener ofpPacketListener) {
+    public OpenflowSouthboundPluginBuilder withPacketListener(final PacketProcessingListener ofpPacketListener) {
         this.ofpPacketListener = ofpPacketListener;
         return this;
     }
@@ -77,7 +77,7 @@ public class OpenflowSouthboundPluginBuilder {
 
         return new OpenflowSouthboundPlugin(lightyServices,
                 ofpConfiguration.getOpenflowProviderConfig(),
-                switchConnectionProviders.getProviders(),
+                switchConnectionProviders.getProviders(lightyServices.getDiagStatusService()),
                 executorService,
                 this.forwardingRulesManagerConfigBuilder,
                 this.ofpPacketListener);

--- a/lighty-modules/lighty-openflow-sb/src/main/java/io/lighty/modules/southbound/openflow/impl/config/SwitchConfig.java
+++ b/lighty-modules/lighty-openflow-sb/src/main/java/io/lighty/modules/southbound/openflow/impl/config/SwitchConfig.java
@@ -8,6 +8,9 @@
 package io.lighty.modules.southbound.openflow.impl.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.List;
+import org.opendaylight.infrautils.diagstatus.DiagStatusService;
 import org.opendaylight.openflowjava.protocol.impl.core.SwitchConnectionProviderFactoryImpl;
 import org.opendaylight.openflowjava.protocol.spi.connection.SwitchConnectionProvider;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.openflow.config.rev140630.KeystoreType;
@@ -16,8 +19,6 @@ import org.opendaylight.yang.gen.v1.urn.opendaylight.openflow.config.rev140630.T
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.openflow._switch.connection.config.rev160506.SwitchConnectionConfig;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.openflow._switch.connection.config.rev160506.SwitchConnectionConfigBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.openflow._switch.connection.config.rev160506._switch.connection.config.TlsBuilder;
-import java.util.ArrayList;
-import java.util.List;
 
 public class SwitchConfig {
 
@@ -92,14 +93,16 @@ public class SwitchConfig {
                         ).build();
     }
 
-    public List<SwitchConnectionProvider> getDefaultProviders() {
+    public List<SwitchConnectionProvider> getDefaultProviders(final DiagStatusService diagStatusService) {
+        final SwitchConnectionProviderFactoryImpl factory = new SwitchConnectionProviderFactoryImpl(diagStatusService);
+
         final List<SwitchConnectionProvider> switchConnectionProviderList = new ArrayList<>();
-        switchConnectionProviderList.add(new SwitchConnectionProviderFactoryImpl().newInstance(this.defaultSwitch));
-        switchConnectionProviderList.add(new SwitchConnectionProviderFactoryImpl().newInstance(this.legacySwitch));
+        switchConnectionProviderList.add(factory.newInstance(this.defaultSwitch));
+        switchConnectionProviderList.add(factory.newInstance(this.legacySwitch));
         return switchConnectionProviderList;
     }
 
-    public List<SwitchConnectionProvider> getProviders() {
+    public List<SwitchConnectionProvider> getProviders(final DiagStatusService diagStatusService) {
 
         final SwitchConnectionConfig tmpDefaultSwitch =
                 new SwitchConnectionConfigBuilder()
@@ -145,9 +148,11 @@ public class SwitchConfig {
                         .build()
                         ).setGroupAddModEnabled(true).build();
 
+        final SwitchConnectionProviderFactoryImpl factory = new SwitchConnectionProviderFactoryImpl(diagStatusService);
+
         final List<SwitchConnectionProvider> switchConnectionProviderList = new ArrayList<>();
-        switchConnectionProviderList.add(new SwitchConnectionProviderFactoryImpl().newInstance(tmpDefaultSwitch));
-        switchConnectionProviderList.add(new SwitchConnectionProviderFactoryImpl().newInstance(tmpLegacySwitch));
+        switchConnectionProviderList.add(factory.newInstance(tmpDefaultSwitch));
+        switchConnectionProviderList.add(factory.newInstance(tmpLegacySwitch));
         return switchConnectionProviderList;
     }
 

--- a/lighty-modules/lighty-ovsdb-sb/pom.xml
+++ b/lighty-modules/lighty-ovsdb-sb/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/pom.xml
+++ b/lighty-modules/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-modules-aggregator</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
 

--- a/lighty-resources/controller-application-assembly/pom.xml
+++ b/lighty-resources/controller-application-assembly/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/log4j-properties/pom.xml
+++ b/lighty-resources/log4j-properties/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/pom.xml
+++ b/lighty-resources/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.resources</groupId>
     <artifactId>lighty-resources-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/lighty-resources/singlenode-configuration/pom.xml
+++ b/lighty-resources/singlenode-configuration/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty</groupId>
     <artifactId>lighty-aggregator</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>lighty-core</name>
 


### PR DESCRIPTION
This bumps lighty-core to 9.3.0-SNAPSHOT and adopts Fluorine SR3 upstream versions.