### PR TITLE
Switch to openjdk8/11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 jdk:
- - oraclejdk8
- - oraclejdk11
+ - openjdk8
+ - openjdk11
 
 before_install:
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-


### PR DESCRIPTION
Do not use oraclejdk, but rather openjdk.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>