### PR TITLE
fix lighty-swagger failing tests

### DIFF
--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyDRAFT02Test.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyDRAFT02Test.java
@@ -9,10 +9,36 @@
 package io.lighty.swagger;
 
 import io.lighty.modules.northbound.restconf.community.impl.config.JsonRestConfServiceType;
+import org.testng.annotations.Test;
 
 public class SwaggerLightyDRAFT02Test extends SwaggerLightyTest {
 
     protected SwaggerLightyDRAFT02Test() {
         super(JsonRestConfServiceType.DRAFT_02);
+    }
+
+    @Test
+    public void simpleSwaggerModuleTest() {
+        super.simpleSwaggerModuleTest();
+    }
+
+    @Test
+    public void testGetListOfMounts() {
+        super.testGetListOfMounts();
+    }
+
+    @Test
+    public void testGetRootDoc() {
+        super.testGetRootDoc();
+    }
+
+    @Test
+    public void testGetDocByModule() {
+        super.testGetDocByModule();
+    }
+
+    @Test
+    public void testGetApiExplorer() {
+        super.testGetApiExplorer();
     }
 }

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyDRAFT18Test.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyDRAFT18Test.java
@@ -9,10 +9,36 @@
 package io.lighty.swagger;
 
 import io.lighty.modules.northbound.restconf.community.impl.config.JsonRestConfServiceType;
+import org.testng.annotations.Test;
 
 public class SwaggerLightyDRAFT18Test extends SwaggerLightyTest {
 
     protected SwaggerLightyDRAFT18Test() {
         super(JsonRestConfServiceType.DRAFT_18);
+    }
+
+    @Test
+    public void simpleSwaggerModuleTest() {
+        super.simpleSwaggerModuleTest();
+    }
+
+    @Test
+    public void testGetListOfMounts() {
+        super.testGetListOfMounts();
+    }
+
+    @Test
+    public void testGetRootDoc() {
+        super.testGetRootDoc();
+    }
+
+    @Test
+    public void testGetDocByModule() {
+        super.testGetDocByModule();
+    }
+
+    @Test
+    public void testGetApiExplorer() {
+        super.testGetApiExplorer();
     }
 }

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTest.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTest.java
@@ -15,9 +15,10 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.annotations.Ignore;
-import org.testng.annotations.Test;
 
+/**
+ * Base class for lighty-swagger tests for different versions of {@link JsonRestConfServiceType}
+ */
 public abstract class SwaggerLightyTest extends SwaggerLightyTestBase {
 
     private String modelName;
@@ -40,13 +41,11 @@ public abstract class SwaggerLightyTest extends SwaggerLightyTestBase {
         Mockito.when(uriInfo.getRequestUriBuilder()).thenReturn(UriBuilder.fromUri(absolutePath));
     }
 
-    @Test
     public void simpleSwaggerModuleTest() {
         Assert.assertNotNull(getLightyController());
         Assert.assertNotNull(getSwaggerModule());
     }
 
-    @Test
     public void testGetListOfMounts() {
 
         final Response response = getSwaggerModule().getApiDocService().getListOfMounts(uriInfo);
@@ -54,17 +53,12 @@ public abstract class SwaggerLightyTest extends SwaggerLightyTestBase {
         Assert.assertEquals(200, response.getStatus());
     }
 
-    @Test
-    @Ignore
     public void testGetMountRootDoc() {
     }
 
-    @Test
-    @Ignore
     public void testGetMountDocByModule() {
     }
 
-    @Test
     public void testGetRootDoc() {
 
         final Response response = getSwaggerModule().getApiDocService().getRootDoc(uriInfo);
@@ -73,7 +67,6 @@ public abstract class SwaggerLightyTest extends SwaggerLightyTestBase {
         Assert.assertNotNull(response.getEntity());
     }
 
-    @Test
     public void testGetDocByModule() {
 
         final Response response = getSwaggerModule().getApiDocService().getDocByModule(modelName, revisionDate, uriInfo);
@@ -82,7 +75,6 @@ public abstract class SwaggerLightyTest extends SwaggerLightyTestBase {
         Assert.assertNotNull(response.getEntity());
     }
 
-    @Test
     public void testGetApiExplorer() {
 
         final Response response = getSwaggerModule().getApiDocService().getApiExplorer(uriInfo);

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
@@ -26,6 +26,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
+/**
+ * Base class for lighty-swagger tests handlin starting and shutting-down of lighty with restConf and swagger module
+ */
 public abstract class SwaggerLightyTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerLightyTestBase.class);


### PR DESCRIPTION
lighty-swagger tests failing observed on some machines:
 ubuntu 19.04, openJDK 11.0.3+7-Ubuntu-1ubuntu219.04.1, maven 3.6.1

default port bound by actor system server was not released so subsequent
 tests were failing, after @Test methods were extracted from parent
 class the port is correctly released and subsequent tests can possibly
 bound same default port