### PR TITLE
Remove arbitratorreconciliation-impl declaration

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -104,11 +104,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.opendaylight.openflowplugin.applications</groupId>
-                <artifactId>arbitratorreconciliation-impl</artifactId>
-                <version>0.9.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
                 <version>0.4.0-SNAPSHOT</version>


### PR DESCRIPTION
The declaration is now part of openflowplugin-artifacts, hence
we do not need to repeat it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>