### PR TITLE
Bump jcommander to 1.78

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -136,7 +136,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.72</version>
+                <version>1.78</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
There's a new release out, use that.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>