### PR TITLE
Upgrade SpingBoot to 2.2.0

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.8.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
This updates the example to use latest spring boot.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>