### PR TITLE
Remove dependencies outside of Maven Central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 
 jdk:

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -449,9 +449,12 @@
             <version>0.7</version>
         </dependency>
         <dependency>
-            <groupId>org.fusesource.leveldbjni</groupId>
+            <groupId>org.opendaylight.odlparent</groupId>
             <artifactId>leveldbjni-all</artifactId>
+            <!-- All versions should be equivalent, pick the latest one -->
+            <version>6.0.3</version>
         </dependency>
+
         <!--odl-mdsal-remoterpc-connector-->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
@@ -473,6 +476,13 @@
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-datastore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- JSR173 ships with JRE by default -->
+                    <groupId>com.bea.xml</groupId>
+                    <artifactId>jsr173-ri</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -34,10 +34,25 @@
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-nb-bierman02</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- JSR173 ships with JRE by default -->
+                    <groupId>com.bea.xml</groupId>
+                    <artifactId>jsr173-ri</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-nb-rfc8040</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- JSR173 ships with JRE by default -->
+                    <groupId>com.bea.xml</groupId>
+                    <artifactId>jsr173-ri</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Jersey + Jetty for RESTCONF -->


### PR DESCRIPTION
This applies some creative filtering to ensure we do not depend
on dependencies which are available in central only.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>