### PR TITLE
Fix SR mis-reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 
-_This branch maintains compatibility with __OpenDaylight Sodium SR1__ release._
+_This branch maintains compatibility with __OpenDaylight Sodium SR2__ release._
 
 ## Features
 - [x] __Removed Karaf__: Having Java SE as a runtime, you can use a framework of your choice, not only Karaf


### PR DESCRIPTION
11.2.x tracks Sodium SR2, not SR1.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>