### PR TITLE
Remove dependencies outside of Maven Central

### DIFF
--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -444,9 +444,10 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.fusesource.leveldbjni</groupId>
+            <groupId>org.opendaylight.odlparent</groupId>
             <artifactId>leveldbjni-all</artifactId>
-            <version>1.8-odl</version>
+            <!-- All versions should be equivalent, pick the latest one -->
+            <version>6.0.3</version>
         </dependency>
 
         <!--odl-mdsal-remoterpc-connector-->
@@ -470,6 +471,13 @@
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-datastore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- JSR173 ships with JRE by default -->
+                    <groupId>com.bea.xml</groupId>
+                    <artifactId>jsr173-ri</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -35,10 +35,25 @@
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-nb-bierman02</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- JSR173 ships with JRE by default -->
+                    <groupId>com.bea.xml</groupId>
+                    <artifactId>jsr173-ri</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-nb-rfc8040</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- JSR173 ships with JRE by default -->
+                    <groupId>com.bea.xml</groupId>
+                    <artifactId>jsr173-ri</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Jersey + Jetty for RESTCONF -->


### PR DESCRIPTION
This applies some creative filtering to ensure we do not depend
on dependencies which are available in central only.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>