### PR TITLE
We should only be needing ODL repositories for snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 
 before_install:
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-  - wget https://raw.githubusercontent.com/opendaylight/odlparent/master/settings.xml; cp ./settings.xml $HOME/.m2/settings.xml
+  - cp ./settings.xml $HOME/.m2/settings.xml
 
 cache:
   directories:

--- a/settings.xml
+++ b/settings.xml
@@ -11,38 +11,6 @@
 
   <profiles>
     <profile>
-      <id>opendaylight-release</id>
-      <repositories>
-        <repository>
-          <id>opendaylight-mirror</id>
-          <name>opendaylight-mirror</name>
-          <url>https://nexus.opendaylight.org/content/repositories/public/</url>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>opendaylight-mirror</id>
-          <name>opendaylight-mirror</name>
-          <url>https://nexus.opendaylight.org/content/repositories/public/</url>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-
-    <profile>
       <id>opendaylight-snapshots</id>
       <repositories>
         <repository>
@@ -74,7 +42,6 @@
   </profiles>
 
   <activeProfiles>
-    <activeProfile>opendaylight-release</activeProfile>
     <activeProfile>opendaylight-snapshots</activeProfile>
   </activeProfiles>
 </settings>


### PR DESCRIPTION
All ODL-released artifacts are present in Maven Central, hence
we can fetch them from there.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>