### PR TITLE
Remove web-jetty-impl version override

### DIFF
--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.opendaylight.aaa.web</groupId>
             <artifactId>web-jetty-impl</artifactId>
-            <version>0.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
We are getting this version from aaa-artifacts, do not override
it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>