### PR TITLE
Fix headline release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lighty.io 11.1
+# lighty.io 11.2
 __lighty.io__ is a Software Development Kit powered by [OpenDaylight](https://www.opendaylight.org/) to support, ease & accelerate the development of
 Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech](https://pantheon.tech).
 


### PR DESCRIPTION
This was missed in the original bump, correct the name to 11.2.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>