### PR TITLE
Remove junit override

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -30,14 +30,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Overrides of odlparent -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
-
             <!-- OpenDaylight projects -->
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>


### PR DESCRIPTION
odlparent is providing a more modern JUnit-4.13, remove the override.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>