### PR TITLE
Add 'report' goal to jacoco-maven-plugin

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -106,11 +106,18 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.4</version>
+                    <version>0.8.5</version>
                     <executions>
                         <execution>
+                            <id>jacoco-prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>jacoco-report</id>
+                            <goals>
+                                <goal>report</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
Add 'report' goal to jacoco-maven-plugin to fix SonarCloud reporting 0% test coverage.

Signed-off-by: Samuel Kontris <samuel.kontris@pantheon.tech>