### PR TITLE
Disable shallow clone in Travis (cherry-pick from master to 12.1.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: java
 jdk:
   - openjdk11
 
+# disable shallow clone so SonarCloud can use SCM history to compute blame data
+git:
+  depth: false
+
 # the first part of the cache phase happens
 # between git checkout and before_install
 cache:


### PR DESCRIPTION
By disabling git shallow clone in Travis SonarCloud will have
access to SCM history so it can compute blame data.

Signed-off-by: Samuel Kontris <samuel.kontris@pantheon.tech>